### PR TITLE
Enable right-click mouse toggle outside drag look

### DIFF
--- a/script.js
+++ b/script.js
@@ -131,6 +131,7 @@
 
     let fallbackActive = false;
     let isActive = false;
+    let mouseEnabled = false;
 
     function showUI(active){
       overlay.style.display = active ? 'none' : 'grid';
@@ -166,8 +167,22 @@
     }
 
     startBtn.addEventListener('click', tryEnter);
-    controls.addEventListener('lock', ()=>{ isActive=true; fallbackActive=false; showUI(true); updatePreview(); });
-    controls.addEventListener('unlock', ()=>{ isActive=false; showUI(false); });
+
+    window.addEventListener('mousedown', (e)=>{
+      if(e.button === 2 && !fallbackActive){
+        e.preventDefault();
+        if(controls.isLocked){
+          mouseEnabled = true;
+          controls.unlock();
+        }else if(mouseEnabled){
+          mouseEnabled = false;
+          controls.lock();
+        }
+      }
+    });
+
+    controls.addEventListener('lock', ()=>{ isActive=true; fallbackActive=false; mouseEnabled=false; showUI(true); updatePreview(); });
+    controls.addEventListener('unlock', ()=>{ if(mouseEnabled){ showUI(true); } else { isActive=false; showUI(false); } });
 
     // Movement
     const move = { forward:false, back:false, left:false, right:false, run:false };


### PR DESCRIPTION
## Summary
- Add `mouseEnabled` flag and event handler to toggle pointer lock with right click
- Keep UI active when releasing the cursor for interactions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897d2c22a58832a8eb68829d1f8c57e