### PR TITLE
Add shader-driven blocks with soft shadow rendering

### DIFF
--- a/js/core/environment.js
+++ b/js/core/environment.js
@@ -15,6 +15,8 @@ const renderer = new THREE.WebGLRenderer({ antialias: true });
 renderer.setPixelRatio(Math.min(devicePixelRatio, 2));
 renderer.setSize(window.innerWidth, window.innerHeight);
 renderer.shadowMap.enabled = true;
+// Use soft shadows for a smoother appearance
+renderer.shadowMap.type = THREE.PCFSoftShadowMap;
 document.body.appendChild(renderer.domElement);
 
 // Atmosphere sky

--- a/js/core/shaders.js
+++ b/js/core/shaders.js
@@ -1,0 +1,17 @@
+import { THREE } from './environment.js';
+
+// Create a basic lambert shader material with shadow support
+// color: hexadecimal color value for the block
+function createBlockMaterial(color) {
+  // Clone lambert shader uniforms so each material has its own set
+  const uniforms = THREE.UniformsUtils.clone(THREE.ShaderLib.lambert.uniforms);
+  uniforms.diffuse.value = new THREE.Color(color);
+  return new THREE.ShaderMaterial({
+    uniforms,
+    vertexShader: THREE.ShaderLib.lambert.vertexShader,
+    fragmentShader: THREE.ShaderLib.lambert.fragmentShader,
+    lights: true,
+  });
+}
+
+export { createBlockMaterial };

--- a/js/core/world.js
+++ b/js/core/world.js
@@ -1,5 +1,6 @@
 import { THREE, scene } from './environment.js';
 import { ground } from './terrain.js';
+import { createBlockMaterial } from './shaders.js';
 
 const grid = new THREE.GridHelper(400, 80, 0x7aa2ff, 0x2b3d55);
 grid.material.opacity = 0.25;
@@ -15,10 +16,9 @@ blocks.add(chunksGroup);
 const userGroup = new THREE.Group();
 blocks.add(userGroup);
 
-const baseMat = new THREE.MeshStandardMaterial({ color: 0x6ee7ff, roughness: 0.6, metalness: 0.15 });
-function addBlockTo(group, x, y, z, sx = 4, sy = 1, sz = 4, color = null) {
-  const mat = baseMat.clone();
-  if (color !== null) mat.color = new THREE.Color(color);
+function addBlockTo(group, x, y, z, sx = 4, sy = 1, sz = 4, color = 0x6ee7ff) {
+  // Use custom shader material for lighting and shadow support
+  const mat = createBlockMaterial(color);
   const m = new THREE.Mesh(new THREE.BoxGeometry(sx, sy, sz), mat);
   m.position.set(x, y + sy / 2, z);
   m.castShadow = m.receiveShadow = true;


### PR DESCRIPTION
## Summary
- add lambert shader material for blocks with shadow support
- enable soft shadows in renderer for smoother results

## Testing
- `node js/tests.js` *(fails: Cannot find package 'three')*


------
https://chatgpt.com/codex/tasks/task_e_6897dd34f7e4832aad1b2568717ed782