### PR TITLE
Add shader-driven blocks with soft shadow rendering

### DIFF
--- a/js/core/environment.js
+++ b/js/core/environment.js
@@ -15,6 +15,8 @@ const renderer = new THREE.WebGLRenderer({ antialias: true });
 renderer.setPixelRatio(Math.min(devicePixelRatio, 2));
 renderer.setSize(window.innerWidth, window.innerHeight);
 renderer.shadowMap.enabled = true;
+// Use soft shadows for a smoother appearance
+renderer.shadowMap.type = THREE.PCFSoftShadowMap;
 document.body.appendChild(renderer.domElement);
 
 // Atmosphere sky
@@ -37,11 +39,19 @@ setSun(22, 140);
 // Lights
 const hemi = new THREE.HemisphereLight(0xddeeff, 0x223344, 0.8);
 scene.add(hemi);
-const dir = new THREE.DirectionalLight(0xffffff, 0.9);
-dir.position.set(20, 80, 10);
-dir.castShadow = true;
-dir.shadow.mapSize.set(2048, 2048);
-scene.add(dir);
+const sunLight = new THREE.DirectionalLight(0xffffff, 0.9);
+sunLight.position.set(20, 80, 10);
+sunLight.castShadow = true;
+sunLight.shadow.mapSize.set(2048, 2048);
+// Widen the shadow camera so distant blocks can still receive and cast shadows
+const shadowRange = 100;
+sunLight.shadow.camera.near = 1;
+sunLight.shadow.camera.far = 500;
+sunLight.shadow.camera.left = -shadowRange;
+sunLight.shadow.camera.right = shadowRange;
+sunLight.shadow.camera.top = shadowRange;
+sunLight.shadow.camera.bottom = -shadowRange;
+scene.add(sunLight);
 
 // Controls
 const controls = new PointerLockControls(camera, document.body);
@@ -56,4 +66,5 @@ export {
   renderer,
   controls,
   setSun,
+  sunLight,
 };

--- a/js/core/index.js
+++ b/js/core/index.js
@@ -6,6 +6,7 @@ export {
   camera,
   renderer,
   controls,
+  sunLight,
 } from './environment.js';
 export { ground, heightAt, maybeRecenterGround, rebuildGround } from './terrain.js';
 export {

--- a/js/core/shaders.js
+++ b/js/core/shaders.js
@@ -1,0 +1,17 @@
+import { THREE } from './environment.js';
+
+// Create a basic lambert shader material with shadow support
+// color: hexadecimal color value for the block
+function createBlockMaterial(color) {
+  // Clone lambert shader uniforms so each material has its own set
+  const uniforms = THREE.UniformsUtils.clone(THREE.ShaderLib.lambert.uniforms);
+  uniforms.diffuse.value = new THREE.Color(color);
+  return new THREE.ShaderMaterial({
+    uniforms,
+    vertexShader: THREE.ShaderLib.lambert.vertexShader,
+    fragmentShader: THREE.ShaderLib.lambert.fragmentShader,
+    lights: true,
+  });
+}
+
+export { createBlockMaterial };

--- a/js/core/world.js
+++ b/js/core/world.js
@@ -1,5 +1,6 @@
 import { THREE, scene } from './environment.js';
 import { ground } from './terrain.js';
+import { createBlockMaterial } from './shaders.js';
 
 const grid = new THREE.GridHelper(400, 80, 0x7aa2ff, 0x2b3d55);
 grid.material.opacity = 0.25;
@@ -15,10 +16,9 @@ blocks.add(chunksGroup);
 const userGroup = new THREE.Group();
 blocks.add(userGroup);
 
-const baseMat = new THREE.MeshStandardMaterial({ color: 0x6ee7ff, roughness: 0.6, metalness: 0.15 });
-function addBlockTo(group, x, y, z, sx = 4, sy = 1, sz = 4, color = null) {
-  const mat = baseMat.clone();
-  if (color !== null) mat.color = new THREE.Color(color);
+function addBlockTo(group, x, y, z, sx = 4, sy = 1, sz = 4, color = 0x6ee7ff) {
+  // Use custom shader material for lighting and shadow support
+  const mat = createBlockMaterial(color);
   const m = new THREE.Mesh(new THREE.BoxGeometry(sx, sy, sz), mat);
   m.position.set(x, y + sy / 2, z);
   m.castShadow = m.receiveShadow = true;

--- a/js/player/movement.js
+++ b/js/player/movement.js
@@ -4,6 +4,7 @@ import {
   controls,
   camera,
   renderer,
+  sunLight,
   ground,
   blocks,
   fpsBox,
@@ -310,6 +311,10 @@ function animate() {
     }
 
     maybeRecenterGround(obj.position.x, obj.position.z);
+    // Reposition sunlight to follow the player for consistent shadow coverage
+    sunLight.position.set(obj.position.x + 20, obj.position.y + 80, obj.position.z + 10);
+    sunLight.target.position.set(obj.position.x, obj.position.y, obj.position.z);
+    sunLight.target.updateMatrixWorld();
   }
 
   renderer.render(scene, camera);


### PR DESCRIPTION
## Summary
- expand directional light shadow camera bounds and export sunLight
- re-export sunLight through core index for shared access
- move sunLight with the player to maintain shadows for newly placed blocks

## Testing
- `npm init -y` *(warn: Unknown env config "http-proxy")*
- `npm install three` *(fails: 403 Forbidden - GET https://registry.npmjs.org/three)*
- `node js/tests.js` *(fails: Cannot find package 'three')*


------
https://chatgpt.com/codex/tasks/task_e_6897dd34f7e4832aad1b2568717ed782