### PR TITLE
Disable context menu on right click

### DIFF
--- a/js/player/controls.js
+++ b/js/player/controls.js
@@ -107,6 +107,11 @@ window.addEventListener('mousedown', (e) => {
   }
 });
 
+window.addEventListener('contextmenu', (e) => {
+  // block context menu when right click toggles pointer lock
+  if (!fallbackActive) e.preventDefault();
+});
+
 controls.addEventListener('lock', () => {
   state.isActive = true;
   fallbackActive = false;


### PR DESCRIPTION
## Summary
- prevent browser context menu when right-click toggles pointer lock

## Testing
- `node js/tests.js` *(fails: Cannot find package 'three' imported from js/core/environment.js)*

------
https://chatgpt.com/codex/tasks/task_e_6897e1de1c04832a85c9a87285d6c5f7