### PR TITLE
feat: add customizable sun controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,6 +44,16 @@
       <div class="row"><label for="chunkSize">Chunk size</label>
         <input id="chunkSize" type="number" min="8" max="128" step="8" value="32" />
       </div>
+      <h2 style="margin-top:10px">Sun</h2>
+      <div class="row"><label for="sunElev">Elevation</label>
+        <input id="sunElev" type="number" min="0" max="90" step="1" value="22" />
+      </div>
+      <div class="row"><label for="sunAzi">Azimuth</label>
+        <input id="sunAzi" type="number" min="0" max="360" step="1" value="140" />
+      </div>
+      <div class="row"><label for="sunColor">Color</label>
+        <input id="sunColor" type="color" value="#ffffff" />
+      </div>
     </div>
   </div>
 

--- a/js/core/dom.js
+++ b/js/core/dom.js
@@ -23,6 +23,9 @@ const jumpInp = document.getElementById('jump');
 const stepHInp = document.getElementById('stepH');
 const viewDistInp = document.getElementById('viewDist');
 const chunkSizeInp = document.getElementById('chunkSize');
+const sunElevInp = document.getElementById('sunElev');
+const sunAziInp = document.getElementById('sunAzi');
+const sunColorInp = document.getElementById('sunColor');
 
 export {
   overlay,
@@ -49,4 +52,7 @@ export {
   stepHInp,
   viewDistInp,
   chunkSizeInp,
+  sunElevInp,
+  sunAziInp,
+  sunColorInp,
 };

--- a/js/core/environment.js
+++ b/js/core/environment.js
@@ -23,12 +23,14 @@ document.body.appendChild(renderer.domElement);
 const sky = new Sky();
 sky.scale.setScalar(10000);
 scene.add(sky);
-const sun = new THREE.Vector3();
+// Direction vector pointing from origin toward the sun
+const sunDir = new THREE.Vector3();
+// Update sun direction and sky shader based on elevation and azimuth
 function setSun(elevation = 20, azimuth = 130) {
   const phi = THREE.MathUtils.degToRad(90 - elevation);
   const theta = THREE.MathUtils.degToRad(azimuth);
-  sun.setFromSphericalCoords(1, phi, theta);
-  sky.material.uniforms['sunPosition'].value.copy(sun);
+  sunDir.setFromSphericalCoords(1, phi, theta);
+  sky.material.uniforms['sunPosition'].value.copy(sunDir);
 }
 sky.material.uniforms['turbidity'].value = 2.0;
 sky.material.uniforms['rayleigh'].value = 1.2;
@@ -67,4 +69,5 @@ export {
   controls,
   setSun,
   sunLight,
+  sunDir,
 };

--- a/js/core/index.js
+++ b/js/core/index.js
@@ -6,7 +6,9 @@ export {
   camera,
   renderer,
   controls,
+  setSun,
   sunLight,
+  sunDir,
 } from './environment.js';
 export { ground, heightAt, maybeRecenterGround, rebuildGround } from './terrain.js';
 export {
@@ -45,5 +47,8 @@ export {
   stepHInp,
   viewDistInp,
   chunkSizeInp,
+  sunElevInp,
+  sunAziInp,
+  sunColorInp,
 } from './dom.js';
 export { state } from './state.js';

--- a/js/player/movement.js
+++ b/js/player/movement.js
@@ -4,7 +4,9 @@ import {
   controls,
   camera,
   renderer,
+  setSun,
   sunLight,
+  sunDir,
   ground,
   blocks,
   fpsBox,
@@ -14,6 +16,9 @@ import {
   runMulInp,
   jumpInp,
   stepHInp,
+  sunElevInp,
+  sunAziInp,
+  sunColorInp,
   state,
   updateChunks,
   maybeRecenterGround,
@@ -34,6 +39,9 @@ const playerRadius = 0.45;
 let vForward = 0,
   vRight = 0,
   vY = 0;
+let lastElev = 22,
+  lastAzi = 140,
+  lastColor = '#ffffff';
 
 function onKeyDown(e) {
   switch (e.code) {
@@ -256,6 +264,18 @@ function animate() {
     runMul = Math.max(1, parseFloat(runMulInp.value) || 1.8);
     jumpStrength = Math.max(0.1, parseFloat(jumpInp.value) || 11.5);
     stepHeight = Math.max(0, parseFloat(stepHInp.value) || 0.5);
+    const elev = parseFloat(sunElevInp.value) || 22;
+    const azi = parseFloat(sunAziInp.value) || 140;
+    const col = sunColorInp.value || '#ffffff';
+    if (elev !== lastElev || azi !== lastAzi) {
+      setSun(elev, azi);
+      lastElev = elev;
+      lastAzi = azi;
+    }
+    if (col !== lastColor) {
+      sunLight.color.set(col);
+      lastColor = col;
+    }
 
     const speed = walk * (move.run ? runMul : 1);
     const accel = speed * 20;
@@ -312,8 +332,13 @@ function animate() {
 
     maybeRecenterGround(obj.position.x, obj.position.z);
     // Reposition sunlight to follow the player for consistent shadow coverage
-    sunLight.position.set(obj.position.x + 20, obj.position.y + 80, obj.position.z + 10);
-    sunLight.target.position.set(obj.position.x, obj.position.y, obj.position.z);
+    const dist = 100;
+    sunLight.position.set(
+      obj.position.x + sunDir.x * dist,
+      obj.position.y + sunDir.y * dist,
+      obj.position.z + sunDir.z * dist
+    );
+    sunLight.target.position.copy(obj.position);
     sunLight.target.updateMatrixWorld();
   }
 


### PR DESCRIPTION
## Summary
- expose controls for sun elevation, azimuth and color
- track sun direction for shadows and move light with the player

## Testing
- `node js/tests.js` *(fails: Cannot find package 'three')*


------
https://chatgpt.com/codex/tasks/task_e_6897e217a02c832ab8c01a2c5f64ef97