### PR TITLE
Add seeded terrain generation and worldgen settings

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -36,6 +36,7 @@
 
     #settings { left: 12px; top: 12px; }
     #builder { left: 12px; top: 200px; }
+    #worldgen { left: 12px; top: 388px; }
 
     #builderToggle { position: fixed; left: 12px; top: 12px; z-index: 6; padding: 6px 10px; font-size: 12px; border-radius: 10px; border: 1px solid rgba(255,255,255,.15); background: rgba(90,200,250,.25); color: #eaf7ff; cursor: pointer; }
     #builderToggle:hover { filter: brightness(1.05); }

--- a/index.html
+++ b/index.html
@@ -84,6 +84,16 @@
     </div>
   </div>
 
+  <div id="worldgen" class="panel" hidden>
+    <div class="header" id="worldHandle"><span class="title">World Gen</span></div>
+    <div class="panel-body">
+      <div class="row"><label for="seed">Seed</label>
+        <input id="seed" type="number" step="1" value="1" />
+      </div>
+      <button id="regen">Regenerate</button>
+    </div>
+  </div>
+
   <div id="crosshair" hidden></div>
   <div id="hud" hidden>WASD = move | Space = jump | Shift = run</div>
   <div id="fps" hidden>FPS</div>

--- a/js/core/dom.js
+++ b/js/core/dom.js
@@ -27,6 +27,11 @@ const sunElevInp = document.getElementById('sunElev');
 const sunAziInp = document.getElementById('sunAzi');
 const sunColorInp = document.getElementById('sunColor');
 
+const worldgenPanel = document.getElementById('worldgen');
+const worldHandle = document.getElementById('worldHandle');
+const seedInp = document.getElementById('seed');
+const regenBtn = document.getElementById('regen');
+
 export {
   overlay,
   startBtn,
@@ -55,4 +60,8 @@ export {
   sunElevInp,
   sunAziInp,
   sunColorInp,
+  worldgenPanel,
+  worldHandle,
+  seedInp,
+  regenBtn,
 };

--- a/js/core/index.js
+++ b/js/core/index.js
@@ -21,7 +21,7 @@ export {
   blockAABBs,
   rebuildAABBs,
 } from './world.js';
-export { updateChunks, worldToChunk } from './procgen.js';
+export { updateChunks, worldToChunk, resetChunks } from './procgen.js';
 export {
   overlay,
   startBtn,
@@ -50,5 +50,9 @@ export {
   sunElevInp,
   sunAziInp,
   sunColorInp,
+  worldgenPanel,
+  worldHandle,
+  seedInp,
+  regenBtn,
 } from './dom.js';
-export { state } from './state.js';
+export { state, setWorldSeed } from './state.js';

--- a/js/core/procgen.js
+++ b/js/core/procgen.js
@@ -1,6 +1,7 @@
 import { THREE, controls } from './environment.js';
 import { chunksGroup, addBlockTo, rebuildAABBs } from './world.js';
 import { chunkSizeInp, viewDistInp } from './dom.js';
+import { state } from './state.js';
 
 function mulberry32(a) {
   return function () {
@@ -26,7 +27,7 @@ function worldToChunk(x, z) {
 function generateChunk(cx, cz) {
   const g = new THREE.Group();
   g.userData.type = 'chunk';
-  const seed = cx * 73856093 ^ (cz * 19349663);
+  const seed = state.worldSeed ^ (cx * 73856093) ^ (cz * 19349663);
   const rand = mulberry32(seed >>> 0);
   const count = 12 + Math.floor(rand() * 10);
   for (let i = 0; i < count; i++) {
@@ -67,6 +68,14 @@ function unloadChunk(cx, cz) {
   loaded.delete(k);
 }
 
+// Remove all loaded chunks so a new seed can regenerate the world.
+function resetChunks() {
+  for (const k of Array.from(loaded.keys())) {
+    const [cx, cz] = k.split(',').map(Number);
+    unloadChunk(cx, cz);
+  }
+}
+
 let lastChunkUpdate = 0;
 function updateChunks(force = false, forcedPos = null) {
   if (!PROC_ENABLED) return;
@@ -104,4 +113,4 @@ function updateChunks(force = false, forcedPos = null) {
 window.__forceChunkUpdate = (x, z) => updateChunks(true, new THREE.Vector3(x, 0, z));
 updateChunks(true, new THREE.Vector3(0, 0, 0));
 
-export { updateChunks, worldToChunk };
+export { updateChunks, worldToChunk, resetChunks };

--- a/js/core/state.js
+++ b/js/core/state.js
@@ -2,6 +2,12 @@ const state = {
   fallbackActive: false,
   isActive: false,
   mouseEnabled: false,
+  worldSeed: 1,
 };
 
-export { state };
+// Update the global seed used for terrain and chunk generation.
+function setWorldSeed(seed) {
+  state.worldSeed = seed >>> 0;
+}
+
+export { state, setWorldSeed };

--- a/js/core/terrain.js
+++ b/js/core/terrain.js
@@ -1,4 +1,5 @@
 import { THREE, scene } from './environment.js';
+import { state } from './state.js';
 
 const GROUND_SIZE = 800;
 const GROUND_SEG = 128;
@@ -9,8 +10,36 @@ const ground = new THREE.Mesh(groundGeo, groundMat);
 ground.receiveShadow = true;
 scene.add(ground);
 
+// Pseudo-random generator producing deterministic values for terrain.
+function mulberry32(a) {
+  return function () {
+    let t = (a += 0x6d2b79f5);
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+// Simple 2D value noise for hills and valleys.
+function noise2D(x, z) {
+  const sx = Math.floor(x);
+  const sz = Math.floor(z);
+  const fx = x - sx;
+  const fz = z - sz;
+  const seed = state.worldSeed >>> 0;
+  const n00 = mulberry32(seed ^ (sx * 73856093) ^ (sz * 19349663))();
+  const n10 = mulberry32(seed ^ ((sx + 1) * 73856093) ^ (sz * 19349663))();
+  const n01 = mulberry32(seed ^ (sx * 73856093) ^ ((sz + 1) * 19349663))();
+  const n11 = mulberry32(seed ^ ((sx + 1) * 73856093) ^ ((sz + 1) * 19349663))();
+  const nx0 = n00 * (1 - fx) + n10 * fx;
+  const nx1 = n01 * (1 - fx) + n11 * fx;
+  return nx0 * (1 - fz) + nx1 * fz;
+}
+
+// Terrain height biased toward valleys with occasional hills.
 function heightAt(x, z) {
-  return Math.sin(x * 0.05) * Math.cos(z * 0.05) * 0.6;
+  const n = noise2D(x * 0.02, z * 0.02);
+  return (n - 0.6) * 6;
 }
 
 let groundCenter = new THREE.Vector2(0, 0);

--- a/js/main.js
+++ b/js/main.js
@@ -3,3 +3,4 @@ import './builder.js';
 import './ui.js';
 import './player/index.js';
 import './tests.js';
+import './worldgen.js';

--- a/js/player/controls.js
+++ b/js/player/controls.js
@@ -12,6 +12,7 @@ import {
   settingsPanel,
   builder,
   builderToggle,
+  worldgenPanel,
   state,
 } from '../core/index.js';
 import { updatePreview } from '../builder.js';
@@ -26,6 +27,7 @@ function showUI(active) {
   fpsBox.hidden = !active;
   testsBox.hidden = !active;
   settingsPanel.hidden = !active;
+  worldgenPanel.hidden = !active;
   builderToggle.hidden = !active;
   if (!active) builder.hidden = true;
   warnBox.hidden = !(active && fallbackActive);

--- a/js/player/movement.js
+++ b/js/player/movement.js
@@ -12,6 +12,7 @@ import {
   fpsBox,
   settingsPanel,
   builder,
+  worldgenPanel,
   speedInp,
   runMulInp,
   jumpInp,
@@ -356,5 +357,6 @@ window.addEventListener('resize', () => {
   renderer.setSize(window.innerWidth, window.innerHeight);
   constrainPanel(settingsPanel);
   constrainPanel(builder);
+  constrainPanel(worldgenPanel);
 });
 controls.getObject().position.set(0, 1.75 + 1, 8);

--- a/js/tests.js
+++ b/js/tests.js
@@ -34,6 +34,7 @@ export function runTests() {
 
   assert('Settings handle exists', !!document.getElementById('settingsHandle'));
   assert('Builder handle exists', !!document.getElementById('builderHandle'));
+  assert('World gen handle exists', !!document.getElementById('worldHandle'));
 
   const res = assert.results;
   const summary = `Tests: ${res.pass} passed, ${res.fail} failed`;

--- a/js/ui.js
+++ b/js/ui.js
@@ -1,4 +1,11 @@
-import { settingsPanel, settingsHandle, builder, builderHandle } from './core/index.js';
+import {
+  settingsPanel,
+  settingsHandle,
+  builder,
+  builderHandle,
+  worldgenPanel,
+  worldHandle,
+} from './core/index.js';
 
 function constrainPanel(panel) {
   const rect = panel.getBoundingClientRect();
@@ -65,3 +72,4 @@ function makeDraggable(panel, handle, storageKey) {
 
 makeDraggable(settingsPanel, settingsHandle, 'ui.settings.pos');
 makeDraggable(builder, builderHandle, 'ui.builder.pos');
+makeDraggable(worldgenPanel, worldHandle, 'ui.worldgen.pos');

--- a/js/worldgen.js
+++ b/js/worldgen.js
@@ -1,0 +1,19 @@
+import { seedInp, regenBtn, rebuildGround, updateChunks, resetChunks, setWorldSeed } from './core/index.js';
+
+// Generate a random 32-bit seed.
+function randomSeed() {
+  return Math.floor(Math.random() * 0xffffffff);
+}
+
+// Apply seed and rebuild world when the regenerate button is pressed.
+regenBtn.addEventListener('click', () => {
+  let seed = parseInt(seedInp.value);
+  if (!Number.isFinite(seed)) {
+    seed = randomSeed();
+    seedInp.value = seed;
+  }
+  setWorldSeed(seed);
+  rebuildGround();
+  resetChunks();
+  updateChunks(true);
+});


### PR DESCRIPTION
## Summary
- Implement noise-based terrain with seeded valleys and hills
- Add world generation panel with seed controls and regeneration
- Seed chunk generation for deterministic worlds

## Testing
- `node js/tests.js` *(fails: Cannot find package 'three')*

------
https://chatgpt.com/codex/tasks/task_e_6897ea908728832ab09371121113d6aa