### PR TITLE
Keep skybox centered on player

### DIFF
--- a/js/core/environment.js
+++ b/js/core/environment.js
@@ -70,4 +70,5 @@ export {
   setSun,
   sunLight,
   sunDir,
+  sky,
 };

--- a/js/core/index.js
+++ b/js/core/index.js
@@ -9,6 +9,7 @@ export {
   setSun,
   sunLight,
   sunDir,
+  sky,
 } from './environment.js';
 export { ground, heightAt, maybeRecenterGround, rebuildGround } from './terrain.js';
 export {

--- a/js/player/movement.js
+++ b/js/player/movement.js
@@ -7,6 +7,7 @@ import {
   setSun,
   sunLight,
   sunDir,
+  sky,
   ground,
   blocks,
   fpsBox,
@@ -345,6 +346,8 @@ function animate() {
     );
     sunLight.target.position.copy(obj.position);
     sunLight.target.updateMatrixWorld();
+    // Keep skybox centered on the player
+    sky.position.copy(obj.position);
   }
 
   renderer.render(scene, camera);


### PR DESCRIPTION
## Summary
- export the sky object so it can be repositioned
- keep the skybox centered on the player each frame

## Testing
- `node js/tests.js` *(fails: Cannot find package 'three')*

------
https://chatgpt.com/codex/tasks/task_e_6897f04ef8b8832ab5d3b4163331b5e1