### PR TITLE
Improve terrain generation with smooth Perlin mountains

### DIFF
--- a/js/core/terrain.js
+++ b/js/core/terrain.js
@@ -20,29 +20,51 @@ function mulberry32(a) {
   };
 }
 
-// Simple 2D value noise for hills and valleys.
+// Fade curve for smooth interpolation (same as used by Perlin noise).
+function fade(t) {
+  return t * t * t * (t * (t * 6 - 15) + 10);
+}
+
+// 2D Perlin-style gradient noise for smooth hills.
 function noise2D(x, z) {
   const sx = Math.floor(x);
   const sz = Math.floor(z);
   const fx = x - sx;
   const fz = z - sz;
   const seed = state.worldSeed >>> 0;
-  const n00 = mulberry32(seed ^ (sx * 73856093) ^ (sz * 19349663))();
-  const n10 = mulberry32(seed ^ ((sx + 1) * 73856093) ^ (sz * 19349663))();
-  const n01 = mulberry32(seed ^ (sx * 73856093) ^ ((sz + 1) * 19349663))();
-  const n11 = mulberry32(seed ^ ((sx + 1) * 73856093) ^ ((sz + 1) * 19349663))();
-  const nx0 = n00 * (1 - fx) + n10 * fx;
-  const nx1 = n01 * (1 - fx) + n11 * fx;
-  return nx0 * (1 - fz) + nx1 * fz;
+
+  // Create deterministic gradients for the corners of the cell.
+  function gradient(ix, iz) {
+    const r = mulberry32(seed ^ (ix * 73856093) ^ (iz * 19349663))() * Math.PI * 2;
+    return { x: Math.cos(r), z: Math.sin(r) };
+  }
+
+  const g00 = gradient(sx, sz);
+  const g10 = gradient(sx + 1, sz);
+  const g01 = gradient(sx, sz + 1);
+  const g11 = gradient(sx + 1, sz + 1);
+
+  // Dot products between gradient and distance vectors.
+  const d00 = g00.x * fx + g00.z * fz;
+  const d10 = g10.x * (fx - 1) + g10.z * fz;
+  const d01 = g01.x * fx + g01.z * (fz - 1);
+  const d11 = g11.x * (fx - 1) + g11.z * (fz - 1);
+
+  const u = fade(fx);
+  const v = fade(fz);
+
+  const nx0 = d00 + u * (d10 - d00);
+  const nx1 = d01 + u * (d11 - d01);
+  return nx0 + v * (nx1 - nx0);
 }
 
-// Fractal Brownian motion combines multiple noise layers for smoother terrain.
+// Fractal Brownian motion layers multiple noise octaves for detail.
 function fbm2D(x, z) {
   let total = 0;
   let amplitude = 1;
   let frequency = 1;
   let max = 0;
-  for (let i = 0; i < 4; i++) {
+  for (let i = 0; i < 6; i++) {
     total += noise2D(x * frequency, z * frequency) * amplitude;
     max += amplitude;
     amplitude *= 0.5;
@@ -51,10 +73,12 @@ function fbm2D(x, z) {
   return total / max;
 }
 
-// Height map favoring valleys but allowing more mountains with smooth slopes.
+// Height map producing smooth ground with taller mountains.
 function heightAt(x, z) {
-  const n = fbm2D(x * 0.01, z * 0.01);
-  return (n - 0.55) * 20;
+  const n = fbm2D(x * 0.005, z * 0.005);
+  const mountain = Math.pow(Math.max(0, n), 3) * 120;
+  const valley = -Math.pow(Math.max(0, -n), 2) * 20;
+  return mountain + valley;
 }
 
 let groundCenter = new THREE.Vector2(0, 0);


### PR DESCRIPTION
## Summary
- Replace simple value noise with Perlin-style gradient noise and FBM for smoother ground
- Raise mountain peaks and soften valleys for varied elevation

## Testing
- `node js/tests.js` *(fails: Cannot find package 'three')*

------
https://chatgpt.com/codex/tasks/task_e_6897f0aa6f68832a94279b674f4af117