### PR TITLE
Expand view distance and terrain coverage

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
       </div>
       <h2 style="margin-top:10px">World</h2>
       <div class="row"><label for="viewDist">View dist (chunks)</label>
-        <input id="viewDist" type="number" min="1" max="12" step="1" value="5" />
+        <input id="viewDist" type="number" min="1" max="64" step="1" value="10" />
       </div>
       <div class="row"><label for="chunkSize">Chunk size</label>
         <input id="chunkSize" type="number" min="8" max="128" step="8" value="32" />

--- a/js/core/environment.js
+++ b/js/core/environment.js
@@ -5,9 +5,10 @@ import { Sky } from 'three/addons/objects/Sky.js';
 // Scene and camera
 const scene = new THREE.Scene();
 scene.background = new THREE.Color(0x87b3e8);
-scene.fog = new THREE.Fog(0x87b3e8, 120, 1200);
+// Extend fog and camera range so distant chunks remain visible
+scene.fog = new THREE.Fog(0x87b3e8, 120, 3000);
 
-const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 2000);
+const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 5000);
 camera.position.set(0, 1.75, 5);
 camera.rotation.order = 'YXZ';
 
@@ -21,7 +22,8 @@ document.body.appendChild(renderer.domElement);
 
 // Atmosphere sky
 const sky = new Sky();
-sky.scale.setScalar(10000);
+// Enlarge skybox so it remains beyond the furthest view distance
+sky.scale.setScalar(20000);
 scene.add(sky);
 // Direction vector pointing from origin toward the sun
 const sunDir = new THREE.Vector3();

--- a/js/core/index.js
+++ b/js/core/index.js
@@ -11,7 +11,7 @@ export {
   sunDir,
   sky,
 } from './environment.js';
-export { ground, heightAt, maybeRecenterGround, rebuildGround } from './terrain.js';
+export { ground, heightAt, maybeRecenterGround, rebuildGround, ensureGroundSize } from './terrain.js';
 export {
   grid,
   blocks,

--- a/js/core/procgen.js
+++ b/js/core/procgen.js
@@ -2,6 +2,7 @@ import { THREE, controls } from './environment.js';
 import { chunksGroup, addBlockTo, rebuildAABBs } from './world.js';
 import { chunkSizeInp, viewDistInp } from './dom.js';
 import { state } from './state.js';
+import { ensureGroundSize } from './terrain.js';
 
 function mulberry32(a) {
   return function () {
@@ -83,7 +84,9 @@ function updateChunks(force = false, forcedPos = null) {
   if (!force && now - lastChunkUpdate < 250) return;
   lastChunkUpdate = now;
   CHUNK_SIZE = Math.max(8, parseInt(chunkSizeInp.value) || 32);
-  VIEW_DIST = Math.max(1, Math.min(12, parseInt(viewDistInp.value) || 5));
+  VIEW_DIST = Math.max(1, Math.min(64, parseInt(viewDistInp.value) || 10));
+  // Ensure terrain plane spans the current view distance
+  ensureGroundSize((VIEW_DIST * 2 + 2) * CHUNK_SIZE);
 
   const obj = controls.getObject();
   const px = forcedPos ? forcedPos.x : obj.position.x;

--- a/js/core/terrain.js
+++ b/js/core/terrain.js
@@ -1,9 +1,10 @@
 import { THREE, scene } from './environment.js';
 import { state } from './state.js';
 
-const GROUND_SIZE = 800;
+// Allow the ground plane to expand as view distance increases
+let groundSize = 800;
 const GROUND_SEG = 128;
-const groundGeo = new THREE.PlaneGeometry(GROUND_SIZE, GROUND_SIZE, GROUND_SEG, GROUND_SEG);
+let groundGeo = new THREE.PlaneGeometry(groundSize, groundSize, GROUND_SEG, GROUND_SEG);
 groundGeo.rotateX(-Math.PI / 2);
 const groundMat = new THREE.MeshStandardMaterial({ color: 0x35506e, roughness: 0.95 });
 const ground = new THREE.Mesh(groundGeo, groundMat);
@@ -99,15 +100,26 @@ function rebuildGround() {
 }
 rebuildGround();
 
+// Expand ground size to cover the specified area
+function ensureGroundSize(minSize) {
+  if (groundSize >= minSize) return;
+  groundSize = minSize;
+  ground.geometry.dispose();
+  groundGeo = new THREE.PlaneGeometry(groundSize, groundSize, GROUND_SEG, GROUND_SEG);
+  groundGeo.rotateX(-Math.PI / 2);
+  ground.geometry = groundGeo;
+  rebuildGround();
+}
+
 function maybeRecenterGround(playerX, playerZ) {
   const dx = playerX - groundCenter.x;
   const dz = playerZ - groundCenter.y;
-  const threshold = GROUND_SIZE * 0.25;
+  const threshold = groundSize * 0.25;
   if (Math.abs(dx) > threshold || Math.abs(dz) > threshold) {
-    groundCenter.x = Math.round(playerX / (GROUND_SIZE * 0.25)) * (GROUND_SIZE * 0.25);
-    groundCenter.y = Math.round(playerZ / (GROUND_SIZE * 0.25)) * (GROUND_SIZE * 0.25);
+    groundCenter.x = Math.round(playerX / (groundSize * 0.25)) * (groundSize * 0.25);
+    groundCenter.y = Math.round(playerZ / (groundSize * 0.25)) * (groundSize * 0.25);
     rebuildGround();
   }
 }
 
-export { ground, heightAt, maybeRecenterGround, rebuildGround };
+export { ground, heightAt, maybeRecenterGround, rebuildGround, ensureGroundSize };


### PR DESCRIPTION
## Summary
- Allow view distance up to 64 chunks while keeping default at 10
- Enlarge skybox so it remains beyond the expanded view distance

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897f1c2c410832a8a272bb7f528abb8