### PR TITLE
feat: clear blocks and boost terrain

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,6 +81,7 @@
         <input id="sz" type="number" min="0.1" step="0.1" value="4" />
       </div>
       <button id="spawn">Spawn at Crosshair</button>
+      <button id="clearBlocks">Clear Blocks</button>
     </div>
   </div>
 

--- a/js/builder.js
+++ b/js/builder.js
@@ -11,10 +11,12 @@ import {
   syInp,
   szInp,
   spawnBtn,
+  clearBtn,
   ground,
   blocks,
   userGroup,
   blockAABBs,
+  rebuildAABBs,
   state,
 } from './core/index.js';
 
@@ -131,9 +133,16 @@ function spawnAtPreview() {
   addAABBForMesh(mesh);
 }
 
+// Remove all user-placed blocks and refresh collision boxes.
+function clearUserBlocks() {
+  userGroup.clear();
+  rebuildAABBs();
+}
+
 shapeSel.addEventListener('change', updatePreview);
 [sxInp, syInp, szInp].forEach((el) => el.addEventListener('input', updatePreview));
 spawnBtn.addEventListener('click', spawnAtPreview);
+clearBtn.addEventListener('click', clearUserBlocks);
 window.addEventListener('keydown', (e) => {
   if (e.code === 'Enter' && state.isActive) spawnAtPreview();
 });

--- a/js/core/dom.js
+++ b/js/core/dom.js
@@ -17,6 +17,7 @@ const sxInp = document.getElementById('sx');
 const syInp = document.getElementById('sy');
 const szInp = document.getElementById('sz');
 const spawnBtn = document.getElementById('spawn');
+const clearBtn = document.getElementById('clearBlocks');
 const speedInp = document.getElementById('speed');
 const runMulInp = document.getElementById('runmul');
 const jumpInp = document.getElementById('jump');
@@ -51,6 +52,7 @@ export {
   syInp,
   szInp,
   spawnBtn,
+  clearBtn,
   speedInp,
   runMulInp,
   jumpInp,

--- a/js/core/terrain.js
+++ b/js/core/terrain.js
@@ -77,7 +77,8 @@ function fbm2D(x, z) {
 // Height map producing smooth ground with taller mountains.
 function heightAt(x, z) {
   const n = fbm2D(x * 0.005, z * 0.005);
-  const mountain = Math.pow(Math.max(0, n), 3) * 120;
+  // Amplify mountain heights for more dramatic terrain.
+  const mountain = Math.pow(Math.max(0, n), 3) * 240;
   const valley = -Math.pow(Math.max(0, -n), 2) * 20;
   return mountain + valley;
 }


### PR DESCRIPTION
## Summary
- add button to clear all user blocks
- export clear button and wire up builder logic
- double mountain height for more imposing terrain

## Testing
- `node js/tests.js` *(fails: Cannot find package 'three')*

------
https://chatgpt.com/codex/tasks/task_e_6897f4737fcc832a9c0638ca0d940875