### PR TITLE
Fix missing clearBtn export in core index

### DIFF
--- a/js/core/index.js
+++ b/js/core/index.js
@@ -42,6 +42,7 @@ export {
   syInp,
   szInp,
   spawnBtn,
+  clearBtn,
   speedInp,
   runMulInp,
   jumpInp,


### PR DESCRIPTION
## Summary
- fix core module to re-export clearBtn DOM element

## Testing
- `rg clearBtn -n`


------
https://chatgpt.com/codex/tasks/task_e_6897f5ac6ba4832aa40ea64835872de6