### PR TITLE
Add configurable terrain amplification

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,6 +91,12 @@
       <div class="row"><label for="seed">Seed</label>
         <input id="seed" type="number" step="1" value="1" />
       </div>
+      <div class="row"><label for="mountainAmp">Mountain amp</label>
+        <input id="mountainAmp" type="number" step="1" value="240" />
+      </div>
+      <div class="row"><label for="valleyAmp">Valley amp</label>
+        <input id="valleyAmp" type="number" step="1" value="20" />
+      </div>
       <button id="regen">Regenerate</button>
     </div>
   </div>

--- a/js/core/dom.js
+++ b/js/core/dom.js
@@ -32,6 +32,8 @@ const worldgenPanel = document.getElementById('worldgen');
 const worldHandle = document.getElementById('worldHandle');
 const seedInp = document.getElementById('seed');
 const regenBtn = document.getElementById('regen');
+const mountainAmpInp = document.getElementById('mountainAmp');
+const valleyAmpInp = document.getElementById('valleyAmp');
 
 export {
   overlay,
@@ -66,4 +68,6 @@ export {
   worldHandle,
   seedInp,
   regenBtn,
+  mountainAmpInp,
+  valleyAmpInp,
 };

--- a/js/core/index.js
+++ b/js/core/index.js
@@ -42,6 +42,7 @@ export {
   syInp,
   szInp,
   spawnBtn,
+  clearBtn,
   speedInp,
   runMulInp,
   jumpInp,
@@ -55,5 +56,7 @@ export {
   worldHandle,
   seedInp,
   regenBtn,
+  mountainAmpInp,
+  valleyAmpInp,
 } from './dom.js';
-export { state, setWorldSeed } from './state.js';
+export { state, setWorldSeed, setTerrainAmps } from './state.js';

--- a/js/core/state.js
+++ b/js/core/state.js
@@ -3,6 +3,8 @@ const state = {
   isActive: false,
   mouseEnabled: false,
   worldSeed: 1,
+  mountainAmp: 240,
+  valleyAmp: 20,
 };
 
 // Update the global seed used for terrain and chunk generation.
@@ -10,4 +12,10 @@ function setWorldSeed(seed) {
   state.worldSeed = seed >>> 0;
 }
 
-export { state, setWorldSeed };
+// Update terrain amplification factors for mountains and valleys.
+function setTerrainAmps(mountain, valley) {
+  state.mountainAmp = mountain;
+  state.valleyAmp = valley;
+}
+
+export { state, setWorldSeed, setTerrainAmps };

--- a/js/core/terrain.js
+++ b/js/core/terrain.js
@@ -77,9 +77,9 @@ function fbm2D(x, z) {
 // Height map producing smooth ground with taller mountains.
 function heightAt(x, z) {
   const n = fbm2D(x * 0.005, z * 0.005);
-  // Amplify mountain heights for more dramatic terrain.
-  const mountain = Math.pow(Math.max(0, n), 3) * 240;
-  const valley = -Math.pow(Math.max(0, -n), 2) * 20;
+  // Amplify heights using configurable mountain and valley factors.
+  const mountain = Math.pow(Math.max(0, n), 3) * state.mountainAmp;
+  const valley = -Math.pow(Math.max(0, -n), 2) * state.valleyAmp;
   return mountain + valley;
 }
 

--- a/js/worldgen.js
+++ b/js/worldgen.js
@@ -1,10 +1,13 @@
 import {
   seedInp,
   regenBtn,
+  mountainAmpInp,
+  valleyAmpInp,
   rebuildGround,
   updateChunks,
   resetChunks,
   setWorldSeed,
+  setTerrainAmps,
   controls,
   heightAt,
 } from './core/index.js';
@@ -31,6 +34,18 @@ regenBtn.addEventListener('click', () => {
     seedInp.value = seed;
   }
   setWorldSeed(seed);
+  // Validate and apply mountain/valley amplification factors.
+  let mAmp = parseFloat(mountainAmpInp.value);
+  if (!Number.isFinite(mAmp)) {
+    mAmp = 240;
+    mountainAmpInp.value = mAmp;
+  }
+  let vAmp = parseFloat(valleyAmpInp.value);
+  if (!Number.isFinite(vAmp)) {
+    vAmp = 20;
+    valleyAmpInp.value = vAmp;
+  }
+  setTerrainAmps(mAmp, vAmp);
   rebuildGround();
   resetChunks();
   updateChunks(true);


### PR DESCRIPTION
## Summary
- expose mountain and valley amplification fields in world generation UI
- allow runtime configuration of terrain amplifiers through state
- merge latest main to include clearBtn export

## Testing
- `No automated tests available`


------
https://chatgpt.com/codex/tasks/task_e_6897f5776dfc832aa8aa25f1d687d995