### PR TITLE
feat: add object generation toggle

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -40,3 +40,5 @@
 
     #builderToggle { position: fixed; left: 12px; top: 12px; z-index: 6; padding: 6px 10px; font-size: 12px; border-radius: 10px; border: 1px solid rgba(255,255,255,.15); background: rgba(90,200,250,.25); color: #eaf7ff; cursor: pointer; }
     #builderToggle:hover { filter: brightness(1.05); }
+  #procToggle { position: fixed; left: 132px; top: 12px; z-index: 6; padding: 6px 10px; font-size: 12px; border-radius: 10px; border: 1px solid rgba(255,255,255,.15); background: rgba(90,200,250,.25); color: #eaf7ff; cursor: pointer; }
+  #procToggle:hover { filter: brightness(1.05); }

--- a/index.html
+++ b/index.html
@@ -20,6 +20,7 @@
 
   <!-- Settings & Builder panels -->
   <button id="builderToggle" hidden>Builder: On</button>
+  <button id="procToggle" hidden>Objects: Off</button>
 
   <div id="settings" class="panel" hidden>
     <div class="header" id="settingsHandle"><span class="title">Settings</span></div>

--- a/js/builder.js
+++ b/js/builder.js
@@ -17,6 +17,7 @@ import {
   userGroup,
   blockAABBs,
   rebuildAABBs,
+  resetChunks,
   state,
 } from './core/index.js';
 
@@ -136,6 +137,8 @@ function spawnAtPreview() {
 // Remove all user-placed blocks and refresh collision boxes.
 function clearUserBlocks() {
   userGroup.clear();
+  // Also remove procedurally generated blocks
+  resetChunks();
   rebuildAABBs();
 }
 

--- a/js/core/dom.js
+++ b/js/core/dom.js
@@ -11,6 +11,7 @@ const settingsHandle = document.getElementById('settingsHandle');
 const builder = document.getElementById('builder');
 const builderHandle = document.getElementById('builderHandle');
 const builderToggle = document.getElementById('builderToggle');
+const procToggle = document.getElementById('procToggle');
 const shapeSel = document.getElementById('shape');
 const colorInp = document.getElementById('color');
 const sxInp = document.getElementById('sx');
@@ -46,6 +47,7 @@ export {
   builder,
   builderHandle,
   builderToggle,
+  procToggle,
   shapeSel,
   colorInp,
   sxInp,

--- a/js/core/index.js
+++ b/js/core/index.js
@@ -22,7 +22,7 @@ export {
   blockAABBs,
   rebuildAABBs,
 } from './world.js';
-export { updateChunks, worldToChunk, resetChunks } from './procgen.js';
+export { updateChunks, worldToChunk, resetChunks, toggleProcgen } from './procgen.js';
 export {
   overlay,
   startBtn,
@@ -36,6 +36,7 @@ export {
   builder,
   builderHandle,
   builderToggle,
+  procToggle,
   shapeSel,
   colorInp,
   sxInp,

--- a/js/core/procgen.js
+++ b/js/core/procgen.js
@@ -14,7 +14,8 @@ function mulberry32(a) {
 }
 
 const loaded = new Map();
-let PROC_ENABLED = true;
+// Disable procedural object generation by default
+let PROC_ENABLED = false;
 let CHUNK_SIZE = 32;
 let VIEW_DIST = 5;
 
@@ -116,4 +117,15 @@ function updateChunks(force = false, forcedPos = null) {
 window.__forceChunkUpdate = (x, z) => updateChunks(true, new THREE.Vector3(x, 0, z));
 updateChunks(true, new THREE.Vector3(0, 0, 0));
 
-export { updateChunks, worldToChunk, resetChunks };
+function toggleProcgen() {
+  // Toggle procedural generation and rebuild or clear chunks
+  PROC_ENABLED = !PROC_ENABLED;
+  if (!PROC_ENABLED) {
+    resetChunks();
+  } else {
+    updateChunks(true);
+  }
+  return PROC_ENABLED;
+}
+
+export { updateChunks, worldToChunk, resetChunks, toggleProcgen };

--- a/js/player/controls.js
+++ b/js/player/controls.js
@@ -12,6 +12,7 @@ import {
   settingsPanel,
   builder,
   builderToggle,
+  procToggle,
   worldgenPanel,
   state,
 } from '../core/index.js';
@@ -29,6 +30,7 @@ function showUI(active) {
   settingsPanel.hidden = !active;
   worldgenPanel.hidden = !active;
   builderToggle.hidden = !active;
+  procToggle.hidden = !active;
   if (!active) builder.hidden = true;
   warnBox.hidden = !(active && fallbackActive);
 }

--- a/js/worldgen.js
+++ b/js/worldgen.js
@@ -4,6 +4,8 @@ import {
   rebuildGround,
   updateChunks,
   resetChunks,
+  procToggle,
+  toggleProcgen,
   setWorldSeed,
   controls,
   heightAt,
@@ -35,4 +37,10 @@ regenBtn.addEventListener('click', () => {
   resetChunks();
   updateChunks(true);
   alignPlayerToGround();
+});
+
+// Toggle procedural object generation
+procToggle.addEventListener('click', () => {
+  const on = toggleProcgen();
+  procToggle.textContent = on ? 'Objects: On' : 'Objects: Off';
 });


### PR DESCRIPTION
## Summary
- add UI toggle to enable or disable procedural object generation
- clear blocks also resets generated chunks
- default world starts without spawned objects

## Testing
- No tests available

------
https://chatgpt.com/codex/tasks/task_e_6897f7842800832abb36c98af6c88f82