### PR TITLE
Enable terrain self-shadowing

### DIFF
--- a/js/core/index.js
+++ b/js/core/index.js
@@ -11,7 +11,7 @@ export {
   sunDir,
   sky,
 } from './environment.js';
-export { ground, heightAt, maybeRecenterGround, rebuildGround, ensureGroundSize } from './terrain.js';
+export { ground, heightAt, maybeRecenterGround, rebuildGround, setGroundSize } from './terrain.js';
 export {
   grid,
   blocks,

--- a/js/core/procgen.js
+++ b/js/core/procgen.js
@@ -2,7 +2,7 @@ import { THREE, controls } from './environment.js';
 import { chunksGroup, addBlockTo, rebuildAABBs } from './world.js';
 import { chunkSizeInp, viewDistInp } from './dom.js';
 import { state } from './state.js';
-import { ensureGroundSize } from './terrain.js';
+import { setGroundSize } from './terrain.js';
 
 function mulberry32(a) {
   return function () {
@@ -86,8 +86,8 @@ function updateChunks(force = false, forcedPos = null) {
   lastChunkUpdate = now;
   CHUNK_SIZE = Math.max(8, parseInt(chunkSizeInp.value) || 32);
   VIEW_DIST = Math.max(1, Math.min(64, parseInt(viewDistInp.value) || 10));
-  // Ensure terrain plane spans the current view distance
-  ensureGroundSize((VIEW_DIST * 2 + 2) * CHUNK_SIZE);
+  // Sync ground plane to current view distance
+  setGroundSize((VIEW_DIST * 2 + 2) * CHUNK_SIZE);
 
   const obj = controls.getObject();
   const px = forcedPos ? forcedPos.x : obj.position.x;

--- a/js/core/terrain.js
+++ b/js/core/terrain.js
@@ -8,7 +8,8 @@ let groundGeo = new THREE.PlaneGeometry(groundSize, groundSize, GROUND_SEG, GROU
 groundGeo.rotateX(-Math.PI / 2);
 const groundMat = new THREE.MeshStandardMaterial({ color: 0x35506e, roughness: 0.95 });
 const ground = new THREE.Mesh(groundGeo, groundMat);
-ground.receiveShadow = true;
+// Allow terrain to cast shadows on itself so mountains block light.
+ground.castShadow = ground.receiveShadow = true;
 scene.add(ground);
 
 // Pseudo-random generator producing deterministic values for terrain.
@@ -101,10 +102,10 @@ function rebuildGround() {
 }
 rebuildGround();
 
-// Expand ground size to cover the specified area
-function ensureGroundSize(minSize) {
-  if (groundSize >= minSize) return;
-  groundSize = minSize;
+// Resize ground mesh when view distance or chunk size changes
+function setGroundSize(newSize) {
+  if (groundSize === newSize) return;
+  groundSize = newSize;
   ground.geometry.dispose();
   groundGeo = new THREE.PlaneGeometry(groundSize, groundSize, GROUND_SEG, GROUND_SEG);
   groundGeo.rotateX(-Math.PI / 2);
@@ -123,4 +124,4 @@ function maybeRecenterGround(playerX, playerZ) {
   }
 }
 
-export { ground, heightAt, maybeRecenterGround, rebuildGround, ensureGroundSize };
+export { ground, heightAt, maybeRecenterGround, rebuildGround, setGroundSize };


### PR DESCRIPTION
## Summary
- Allow terrain mesh to cast and receive shadows so mountains block sunlight
- Resize ground plane based on view distance so chunk generation matches draw distance

## Testing
- `python -m py_compile $(git ls-files '*.py')` *(fails: the following arguments are required: filenames)*

------
https://chatgpt.com/codex/tasks/task_e_6897f9291d5c832ab9a74b816f154921