### PR TITLE
Add rivers, oceans, and water-aware player alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ The project is a small 3D game experiment. GPT-5 was prompted with the following
 
 From this prompt, GPT-5 produced a basic world rendered through the browser, and Codex later helped refactor and organize the files.
 
+Recent updates expand the terrain system with rivers, lakes, and oceans for a more lifelike landscape.
+
 ## Purpose
 
 The repository demonstrates, in an approachable way, what it looks like to build a small website with AI assistance. Rather than diving into deep technical detail, it showcases the process of:

--- a/js/core/index.js
+++ b/js/core/index.js
@@ -11,7 +11,7 @@ export {
   sunDir,
   sky,
 } from './environment.js';
-export { ground, heightAt, maybeRecenterGround, rebuildGround, setGroundSize } from './terrain.js';
+export { ground, water, SEA_LEVEL, heightAt, maybeRecenterGround, rebuildGround, setGroundSize } from './terrain.js';
 export {
   grid,
   blocks,

--- a/js/worldgen.js
+++ b/js/worldgen.js
@@ -12,6 +12,7 @@ import {
   setTerrainAmps,
   controls,
   heightAt,
+  SEA_LEVEL,
 } from './core/index.js';
 
 // Generate a random 32-bit seed.
@@ -22,7 +23,9 @@ function randomSeed() {
 // Align the player with the terrain at their current position.
 function alignPlayerToGround() {
   const obj = controls.getObject();
-  const groundY = heightAt(obj.position.x, obj.position.z) + 2;
+  const terrainY = heightAt(obj.position.x, obj.position.z);
+  // Keep the player above water if terrain is below sea level.
+  const groundY = Math.max(terrainY, SEA_LEVEL) + 2;
   if (obj.position.y < groundY) {
     obj.position.y = groundY;
   }


### PR DESCRIPTION
## Summary
- extend terrain generation with a sea-level water plane
- carve rivers and lower terrain to create oceans
- keep player above the water surface

## Testing
- No automated tests in repository; none executed

------
https://chatgpt.com/codex/tasks/task_e_6897fb6d9870832aae648fbcebffe147