### PR TITLE
feat: add voxel LOD and caching

### DIFF
--- a/js/core/shaders.js
+++ b/js/core/shaders.js
@@ -1,17 +1,24 @@
 import { THREE } from './environment.js';
 
-// Create a basic lambert shader material with shadow support
+// Cache materials by color to avoid cloning shader uniforms for every voxel
+const materialCache = new Map();
+
+// Return a lambert shader material with shadow support
 // color: hexadecimal color value for the block
 function createBlockMaterial(color) {
-  // Clone lambert shader uniforms so each material has its own set
-  const uniforms = THREE.UniformsUtils.clone(THREE.ShaderLib.lambert.uniforms);
-  uniforms.diffuse.value = new THREE.Color(color);
-  return new THREE.ShaderMaterial({
-    uniforms,
-    vertexShader: THREE.ShaderLib.lambert.vertexShader,
-    fragmentShader: THREE.ShaderLib.lambert.fragmentShader,
-    lights: true,
-  });
+  // Reuse existing material if one was already created for this color
+  if (!materialCache.has(color)) {
+    const uniforms = THREE.UniformsUtils.clone(THREE.ShaderLib.lambert.uniforms);
+    uniforms.diffuse.value = new THREE.Color(color);
+    const mat = new THREE.ShaderMaterial({
+      uniforms,
+      vertexShader: THREE.ShaderLib.lambert.vertexShader,
+      fragmentShader: THREE.ShaderLib.lambert.fragmentShader,
+      lights: true,
+    });
+    materialCache.set(color, mat);
+  }
+  return materialCache.get(color);
 }
 
 export { createBlockMaterial };


### PR DESCRIPTION
## Summary
- add simple level-of-detail rings for terrain voxels
- reuse block materials and geometries to lower memory use

## Testing
- `echo "no tests"`


------
https://chatgpt.com/codex/tasks/task_e_689804f5bc48832a98d87f17d15a384f