### PR TITLE
Fix terrain recentring not reporting updates

### DIFF
--- a/js/world/terrain.js
+++ b/js/world/terrain.js
@@ -71,7 +71,11 @@ function maybeRecenterGround(playerX, playerZ) {
     groundCenter.x = Math.round(playerX / (groundSize * 0.25)) * (groundSize * 0.25);
     groundCenter.y = Math.round(playerZ / (groundSize * 0.25)) * (groundSize * 0.25);
     rebuildGround();
+    // Signal that the terrain was recentered so callers can update collisions.
+    return true;
   }
+  // No recentering needed this frame.
+  return false;
 }
 
 export { ground, water, SEA_LEVEL, heightAt, maybeRecenterGround, rebuildGround, setGroundSize };


### PR DESCRIPTION
## Summary
- Return a boolean from `maybeRecenterGround` to signal when the terrain recenters
- Allow the player loop to rebuild collision bounds only when terrain shifts

## Testing
- `node js/tests.js` *(fails: Cannot find package 'three')*

------
https://chatgpt.com/codex/tasks/task_e_68980ead3860832a9e9de5faae6db021