### PR TITLE
Initialize player position before render loop

### DIFF
--- a/js/player/movement/loop.js
+++ b/js/player/movement/loop.js
@@ -139,6 +139,8 @@ function animate() {
   }
   renderer.render(scene, camera);
 }
+// Set initial player position before starting the loop to avoid a visible teleport.
+controls.getObject().position.set(0, movement.playerHeight + 1, 8);
 animate();
 window.addEventListener('resize', () => {
   camera.aspect = window.innerWidth / window.innerHeight;
@@ -148,4 +150,3 @@ window.addEventListener('resize', () => {
   constrainPanel(builder);
   constrainPanel(worldgenPanel);
 });
-controls.getObject().position.set(0, movement.playerHeight + 1, 8);


### PR DESCRIPTION
## Summary
- avoid startup teleport by placing player before animation begins

## Testing
- `node js/tests.js` *(fails: Cannot find package 'three')*

------
https://chatgpt.com/codex/tasks/task_e_6898101faa64832ab9d5a4938d7770e0