### PR TITLE
Hide builder panel by default

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
   </div>
 
   <!-- Settings & Builder panels -->
-  <button id="builderToggle" hidden>Builder: On</button>
+  <button id="builderToggle" hidden>Builder: Off</button>
   <button id="procToggle" hidden>Objects: Off</button>
 
   <div id="settings" class="panel" hidden>

--- a/js/builder/index.js
+++ b/js/builder/index.js
@@ -31,8 +31,9 @@ function setBuilderVisible(visible) {
 export function toggleBuilder() {
   setBuilderVisible(builder.hidden);
 }
-builderToggle.addEventListener('click', () => toggleBuilder());
-setBuilderVisible(true);
+builderToggle.addEventListener('click', toggleBuilder);
+// Hide builder panel on load so it doesn't appear before the user toggles it.
+setBuilderVisible(false);
 
 function addAABBForMesh(mesh) {
   mesh.updateMatrixWorld(true);


### PR DESCRIPTION
## Summary
- Ensure builder panel starts hidden and only shows when toggled
- Update builder toggle label to match hidden state

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_68988de298cc832aa365b5f19c1d21f6