### PR TITLE
Add debug menu for runtime toggles

### DIFF
--- a/index.html
+++ b/index.html
@@ -102,6 +102,15 @@
     </div>
   </div>
 
+  <div id="debug" class="panel" hidden>
+    <div class="header" id="debugHandle"><span class="title">Debug</span></div>
+    <div class="panel-body">
+      <div class="row"><label><input id="dbgTests" type="checkbox" checked /> Run tests</label></div>
+      <div class="row"><label><input id="dbgMovement" type="checkbox" checked /> Movement</label></div>
+      <div class="row"><label><input id="dbgGround" type="checkbox" checked /> Ground gen</label></div>
+    </div>
+  </div>
+
   <div id="crosshair" hidden></div>
   <div id="hud" hidden>WASD = move | Space = jump | Shift = run</div>
   <div id="fps" hidden>FPS</div>

--- a/js/core/dom.js
+++ b/js/core/dom.js
@@ -37,6 +37,12 @@ const regenBtn = document.getElementById('regen');
 const mountainAmpInp = document.getElementById('mountainAmp');
 const valleyAmpInp = document.getElementById('valleyAmp');
 
+const debugPanel = document.getElementById('debug');
+const debugHandle = document.getElementById('debugHandle');
+const dbgTests = document.getElementById('dbgTests');
+const dbgMovement = document.getElementById('dbgMovement');
+const dbgGround = document.getElementById('dbgGround');
+
 export {
   overlay,
   startBtn,
@@ -74,4 +80,9 @@ export {
   regenBtn,
   mountainAmpInp,
   valleyAmpInp,
+  debugPanel,
+  debugHandle,
+  dbgTests,
+  dbgMovement,
+  dbgGround,
 };

--- a/js/core/index.js
+++ b/js/core/index.js
@@ -60,5 +60,10 @@ export {
   regenBtn,
   mountainAmpInp,
   valleyAmpInp,
+  debugPanel,
+  debugHandle,
+  dbgTests,
+  dbgMovement,
+  dbgGround,
 } from './dom.js';
 export { state, setWorldSeed, setTerrainAmps } from './state.js';

--- a/js/debug.js
+++ b/js/debug.js
@@ -1,0 +1,47 @@
+import {
+  dbgTests,
+  dbgMovement,
+  dbgGround,
+  testsBox,
+} from './core/index.js';
+import { runTests } from './tests.js';
+
+// Track which debug options are enabled.
+const DEBUG = {
+  tests: dbgTests.checked,
+  movement: dbgMovement.checked,
+  ground: dbgGround.checked,
+};
+
+// Expose the debug state globally for other modules.
+window.__DEBUG = DEBUG;
+
+// Run or hide tests based on the checkbox state.
+function applyTests() {
+  DEBUG.tests = dbgTests.checked;
+  testsBox.hidden = !DEBUG.tests;
+  if (DEBUG.tests) {
+    testsBox.textContent = 'Running tests…';
+    runTests();
+  }
+}
+
+// Update movement flag when toggled.
+function applyMovement() {
+  DEBUG.movement = dbgMovement.checked;
+}
+
+// Update ground generation flag when toggled.
+function applyGround() {
+  DEBUG.ground = dbgGround.checked;
+}
+
+dbgTests.addEventListener('change', applyTests);
+dbgMovement.addEventListener('change', applyMovement);
+dbgGround.addEventListener('change', applyGround);
+
+// Initialize all debug options on load.
+applyTests();
+applyMovement();
+applyGround();
+

--- a/js/main.js
+++ b/js/main.js
@@ -2,5 +2,5 @@ import './core/index.js';
 import './builder/index.js';
 import './ui.js';
 import './player/index.js';
-import './tests.js';
 import './world/index.js';
+import './debug.js';

--- a/js/player/controls.js
+++ b/js/player/controls.js
@@ -16,6 +16,7 @@ import {
   procToggle,
   worldgenPanel,
   state,
+  debugPanel,
   } from '../core/index.js';
   import { updatePreview } from '../builder/preview.js';
 
@@ -34,6 +35,8 @@ function showUI(active) {
   builderToggle.hidden = !active;
   procToggle.hidden = !active;
   if (!active) builder.hidden = true;
+  // Show or hide debug options with the main UI.
+  debugPanel.hidden = !active;
   warnBox.hidden = !(active && fallbackActive);
 }
 

--- a/js/player/movement/loop.js
+++ b/js/player/movement/loop.js
@@ -57,7 +57,8 @@ function animate() {
     acc = 0;
   }
   updateChunks();
-  if (state.isActive) {
+  // Only update player motion when enabled in the debug menu.
+  if (state.isActive && (!window.__DEBUG || window.__DEBUG.movement)) {
     const sF = (move.forward ? 1 : 0) - (move.back ? 1 : 0);
     const sR = (move.right ? 1 : 0) - (move.left ? 1 : 0);
     movement.walk = Math.max(0.1, parseFloat(speedInp.value) || 10);

--- a/js/tests.js
+++ b/js/tests.js
@@ -42,4 +42,3 @@ export function runTests() {
   res.details.forEach(tlog);
   testsBox.textContent = summary;
 }
-runTests();

--- a/js/ui.js
+++ b/js/ui.js
@@ -5,6 +5,8 @@ import {
   builderHandle,
   worldgenPanel,
   worldHandle,
+  debugPanel,
+  debugHandle,
 } from './core/index.js';
 
 function constrainPanel(panel) {
@@ -73,3 +75,4 @@ function makeDraggable(panel, handle, storageKey) {
 makeDraggable(settingsPanel, settingsHandle, 'ui.settings.pos');
 makeDraggable(builder, builderHandle, 'ui.builder.pos');
 makeDraggable(worldgenPanel, worldHandle, 'ui.worldgen.pos');
+makeDraggable(debugPanel, debugHandle, 'ui.debug.pos');

--- a/js/world/procgen.js
+++ b/js/world/procgen.js
@@ -83,6 +83,8 @@ function resetChunks() {
 
 let lastChunkUpdate = 0;
 function updateChunks(force = false, forcedPos = null) {
+  // Skip updates when ground generation is disabled via debug menu.
+  if (window.__DEBUG && !window.__DEBUG.ground) return;
   const now = performance.now();
   if (!force && now - lastChunkUpdate < 250) return;
   lastChunkUpdate = now;


### PR DESCRIPTION
## Summary
- Add debug panel with checkboxes to control tests, movement, and ground generation
- Introduce debug module to manage runtime toggles and expose global debug state
- Respect debug flags in movement loop and chunk updates to disable subsystems

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_6898a1499030832aa34553ac5e1c8b52