### PR TITLE
feat: add dynamic day night cycle

### DIFF
--- a/js/core/index.js
+++ b/js/core/index.js
@@ -10,6 +10,7 @@ export {
   sunLight,
   sunDir,
   sky,
+  updateEnvironment,
 } from './environment.js';
 export { ground, water, SEA_LEVEL, heightAt, maybeRecenterGround, rebuildGround, setGroundSize } from '../world/terrain.js';
 export {


### PR DESCRIPTION
## Summary
- drive sun position from a progressing time variable
- interpolate sky, fog, and sunlight colors across day phases
- expose environment updater to game loop

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_6898ba3c6d80832ab3ad0919423d1a45