### PR TITLE
Add sun-based time display

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -15,6 +15,7 @@
     #fps { position: fixed; right: 12px; top: 10px; background: rgba(15,22,30,.55); padding: 6px 10px; border-radius: 8px; font: 12px/1.2 monospace; opacity: .8; }
     #tests { position: fixed; right: 12px; top: 40px; background: rgba(15,22,30,.55); padding: 6px 10px; border-radius: 8px; font: 12px/1.2 monospace; opacity: .85; }
   #pos { position: fixed; right: 12px; top: 70px; background: rgba(15,22,30,.55); padding: 6px 10px; border-radius: 8px; font: 12px/1.2 monospace; opacity: .8; }
+  #time { position: fixed; right: 12px; top: 100px; background: rgba(15,22,30,.55); padding: 6px 10px; border-radius: 8px; font: 12px/1.2 monospace; opacity: .8; }
     #warn { position: fixed; left: 50%; top: 12px; transform: translateX(-50%); background: rgba(255,184,76,.15); color: #ffd08a; border: 1px solid rgba(255,184,76,.35); padding: 6px 10px; border-radius: 10px; font: 12px/1.2 system-ui; z-index: 3; }
 
     /* Crosshair */

--- a/index.html
+++ b/index.html
@@ -116,6 +116,7 @@
   <div id="fps" hidden>FPS</div>
   <div id="tests" hidden>Running tests…</div>
   <div id="pos" hidden>X: 0 Y: 0 Z: 0</div>
+  <div id="time" hidden>00:00</div>
   <div id="warn" hidden>Pointer lock blocked; using drag-to-look (hold mouse to look)</div>
 
   <!-- Import map so bare specifiers resolve in the browser -->

--- a/js/core/dom.js
+++ b/js/core/dom.js
@@ -6,6 +6,7 @@ const fpsBox = document.getElementById('fps');
 const testsBox = document.getElementById('tests');
 const warnBox = document.getElementById('warn');
 const posBox = document.getElementById('pos');
+const timeBox = document.getElementById('time');
 
 const settingsPanel = document.getElementById('settings');
 const settingsHandle = document.getElementById('settingsHandle');
@@ -50,6 +51,7 @@ export {
   crosshair,
   fpsBox,
   posBox,
+  timeBox,
   testsBox,
   warnBox,
   settingsPanel,

--- a/js/core/index.js
+++ b/js/core/index.js
@@ -31,6 +31,7 @@ export {
   crosshair,
   fpsBox,
   posBox,
+  timeBox,
   testsBox,
   warnBox,
   settingsPanel,

--- a/js/player/controls.js
+++ b/js/player/controls.js
@@ -8,6 +8,7 @@ import {
   crosshair,
   fpsBox,
   posBox,
+  timeBox,
   testsBox,
   warnBox,
   settingsPanel,
@@ -29,6 +30,7 @@ function showUI(active) {
   crosshair.hidden = !active;
   fpsBox.hidden = !active;
   posBox.hidden = !active;
+  timeBox.hidden = !active;
   testsBox.hidden = !active;
   settingsPanel.hidden = !active;
   worldgenPanel.hidden = !active;

--- a/js/player/movement/loop.js
+++ b/js/player/movement/loop.js
@@ -12,6 +12,7 @@ import {
   blocks,
   fpsBox,
   posBox,
+  timeBox,
   settingsPanel,
   builder,
   worldgenPanel,
@@ -34,6 +35,15 @@ let last = performance.now(), frames = 0, acc = 0;
 const clock = new THREE.Clock();
 const downRay = new THREE.Raycaster();
 let dayTime = 0; // Tracks passage of time in the day-night cycle
+
+function updateTimeDisplay() {
+  // Convert dayTime (0–1) to total minutes in a 24h cycle
+  const totalMinutes = Math.floor(dayTime * 24 * 60);
+  // Format hours and minutes with leading zeros
+  const hours = String(Math.floor(totalMinutes / 60)).padStart(2, '0');
+  const minutes = String(totalMinutes % 60).padStart(2, '0');
+  timeBox.textContent = `${hours}:${minutes}`;
+}
 function approach(cur, target, maxStep) {
   if (cur < target) return Math.min(target, cur + maxStep);
   if (cur > target) return Math.max(target, cur - maxStep);
@@ -62,6 +72,7 @@ function animate() {
   const sunAz = dayTime * 360;
   setSun(sunElev, sunAz);
   updateEnvironment(sunElev);
+  updateTimeDisplay();
   updateChunks();
   // Only update player motion when enabled in the debug menu.
   if (state.isActive && (!window.__DEBUG || window.__DEBUG.movement)) {


### PR DESCRIPTION
## Summary
- add 24h time readout based on day-night cycle
- expose new time UI element and toggle with player controls
- update time display every frame using sun position

No tests were run per repository instructions.

------
https://chatgpt.com/codex/tasks/task_e_6898c906048c832ab7a175e9e1b50a81