### PR TITLE
Add visible moon with shadows and 6-hour time offset

### DIFF
--- a/js/core/environment.js
+++ b/js/core/environment.js
@@ -81,10 +81,24 @@ sunLight.shadow.camera.top = shadowRange;
 sunLight.shadow.camera.bottom = -shadowRange;
 scene.add(sunLight);
 
-// Add a subtle moon light opposite the sun
-const moonLight = new THREE.DirectionalLight(0xffffff, sunLight.intensity * 0.1);
-moonLight.castShadow = false;
+// Add a moon light opposite the sun
+const moonLight = new THREE.DirectionalLight(0xffffff, 0.2);
+// Let the moon light cast shadows like the sun
+moonLight.castShadow = true;
+moonLight.shadow.mapSize.set(2048, 2048);
+moonLight.shadow.camera.near = 1;
+moonLight.shadow.camera.far = 500;
+moonLight.shadow.camera.left = -shadowRange;
+moonLight.shadow.camera.right = shadowRange;
+moonLight.shadow.camera.top = shadowRange;
+moonLight.shadow.camera.bottom = -shadowRange;
 scene.add(moonLight);
+// Create a simple sphere to represent the visible moon
+const moon = new THREE.Mesh(
+  new THREE.SphereGeometry(5, 16, 16),
+  new THREE.MeshBasicMaterial({ color: 0xffffff })
+);
+scene.add(moon);
 
 // Controls
 const controls = new PointerLockControls(camera, document.body);
@@ -101,6 +115,7 @@ export {
   setSun,
   sunLight,
   moonLight,
+  moon,
   sunDir,
   sky,
   updateEnvironment,

--- a/js/core/index.js
+++ b/js/core/index.js
@@ -9,6 +9,7 @@ export {
   setSun,
   sunLight,
   moonLight,
+  moon,
   sunDir,
   sky,
   updateEnvironment,

--- a/js/player/movement/loop.js
+++ b/js/player/movement/loop.js
@@ -7,6 +7,7 @@ import {
   setSun,
   sunLight,
   moonLight,
+  moon,
   sunDir,
   sky,
   ground,
@@ -39,8 +40,8 @@ const downRay = new THREE.Raycaster();
 let dayTime = 0; // Tracks passage of time in the day-night cycle
 
 function updateTimeDisplay() {
-  // Convert dayTime (0–1) to total minutes in a 24h cycle
-  const totalMinutes = Math.floor(dayTime * 24 * 60);
+  // Convert dayTime (0–1) to total minutes in a 24h cycle with a 6h offset
+  const totalMinutes = Math.floor(((dayTime + 0.25) % 1) * 24 * 60);
   // Format hours and minutes with leading zeros
   const hours = String(Math.floor(totalMinutes / 60)).padStart(2, '0');
   const minutes = String(totalMinutes % 60).padStart(2, '0');
@@ -144,8 +145,8 @@ function animate() {
     sunLight.target.position.copy(obj.position);
     sunLight.target.updateMatrixWorld();
     // Position the moon opposite the sun and apply user-defined strength
-    const moonStrength = Math.max(0, parseFloat(moonStrengthInp.value) || sunLight.intensity * 0.1);
-    moonLight.intensity = moonStrength;
+    const moonStrength = parseFloat(moonStrengthInp.value);
+    moonLight.intensity = Number.isFinite(moonStrength) ? moonStrength : 0.2;
     moonLight.position.set(
       obj.position.x - sunDir.x * dist,
       obj.position.y - sunDir.y * dist,
@@ -153,6 +154,8 @@ function animate() {
     );
     moonLight.target.position.copy(obj.position);
     moonLight.target.updateMatrixWorld();
+    // Keep the visible moon mesh aligned with the light
+    moon.position.copy(moonLight.position);
     sky.position.copy(obj.position);
     // Show current player position in the HUD
     posBox.textContent =


### PR DESCRIPTION
## Summary
- Make moon light cast shadows and represent the moon with a sphere
- Export the moon and align its position with the light
- Offset in-game clock by six hours for natural sunrise and sunset times

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_6898d16c77ec832ab72bc9425cd6ac01