### PR TITLE
Reduce moon light intensity and remove strength control

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,10 +55,6 @@
       <div class="row"><label for="sunColor">Color</label>
         <input id="sunColor" type="color" value="#ffffff" />
       </div>
-      <h2 style="margin-top:10px">Moon</h2>
-      <div class="row"><label for="moonStrength">Strength</label>
-        <input id="moonStrength" type="number" min="0" step="0.01" value="0.09" />
-      </div>
     </div>
   </div>
 

--- a/js/core/dom.js
+++ b/js/core/dom.js
@@ -30,7 +30,6 @@ const chunkSizeInp = document.getElementById('chunkSize');
 const sunElevInp = document.getElementById('sunElev');
 const sunAziInp = document.getElementById('sunAzi');
 const sunColorInp = document.getElementById('sunColor');
-const moonStrengthInp = document.getElementById('moonStrength');
 
 const worldgenPanel = document.getElementById('worldgen');
 const worldHandle = document.getElementById('worldHandle');
@@ -77,7 +76,6 @@ export {
   sunElevInp,
   sunAziInp,
   sunColorInp,
-  moonStrengthInp,
   worldgenPanel,
   worldHandle,
   seedInp,

--- a/js/core/environment.js
+++ b/js/core/environment.js
@@ -81,8 +81,8 @@ sunLight.shadow.camera.top = shadowRange;
 sunLight.shadow.camera.bottom = -shadowRange;
 scene.add(sunLight);
 
-// Add a moon light opposite the sun
-const moonLight = new THREE.DirectionalLight(0xffffff, 0.2);
+// Add a moon light opposite the sun with lower intensity to prevent glare
+const moonLight = new THREE.DirectionalLight(0xffffff, 0.04);
 // Let the moon light cast shadows like the sun
 moonLight.castShadow = true;
 moonLight.shadow.mapSize.set(2048, 2048);

--- a/js/core/index.js
+++ b/js/core/index.js
@@ -58,7 +58,6 @@ export {
   sunElevInp,
   sunAziInp,
   sunColorInp,
-  moonStrengthInp,
   worldgenPanel,
   worldHandle,
   seedInp,

--- a/js/player/movement/loop.js
+++ b/js/player/movement/loop.js
@@ -22,7 +22,6 @@ import {
   runMulInp,
   jumpInp,
   stepHInp,
-  moonStrengthInp,
   state,
   updateChunks,
   maybeRecenterGround,
@@ -144,9 +143,7 @@ function animate() {
     );
     sunLight.target.position.copy(obj.position);
     sunLight.target.updateMatrixWorld();
-    // Position the moon opposite the sun and apply user-defined strength
-    const moonStrength = parseFloat(moonStrengthInp.value);
-    moonLight.intensity = Number.isFinite(moonStrength) ? moonStrength : 0.2;
+    // Position the moon opposite the sun; intensity remains fixed
     moonLight.position.set(
       obj.position.x - sunDir.x * dist,
       obj.position.y - sunDir.y * dist,


### PR DESCRIPTION
## Summary
- Dim moon light to a fixed intensity of 0.04 to prevent it from cutting through the ground
- Remove moon strength input and associated logic so the value is no longer adjustable

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_6898d3e5f6ac832aa673ecfb21834e39