### PR TITLE
Enhance terrain noise and preserve detail

### DIFF
--- a/js/world/heightmap.js
+++ b/js/world/heightmap.js
@@ -65,8 +65,11 @@ function fbm2D(x, z) {
 
 // Height map producing smooth ground with mountains, valleys, and rivers.
 function heightAt(x, z) {
-  // Increase noise frequency so mountains are packed closer together.
-  const n = fbm2D(x * 0.01, z * 0.01);
+  // Blend several noise layers for varied terrain features.
+  const base = fbm2D(x * 0.01, z * 0.01); // medium-scale mountains
+  const continent = fbm2D((x + 1000) * 0.002, (z + 1000) * 0.002); // large landmasses
+  const detail = fbm2D((x - 1000) * 0.05, (z - 1000) * 0.05) * 0.1; // fine detail
+  const n = base * 0.6 + continent * 0.3 + detail; // combine noise layers
   // Amplify heights using configurable mountain and valley factors.
   const mountain = Math.pow(Math.max(0, n), 3) * state.mountainAmp;
   const valley = -Math.pow(Math.max(0, -n), 2) * state.valleyAmp;

--- a/js/world/terrain.js
+++ b/js/world/terrain.js
@@ -7,9 +7,14 @@ const SEA_LEVEL = -10;
 
 // Allow the ground plane to expand as view distance increases
 let groundSize = 800;
-const GROUND_SEG = 128;
-let groundGeo = new THREE.PlaneGeometry(groundSize, groundSize, GROUND_SEG, GROUND_SEG);
-groundGeo.rotateX(-Math.PI / 2);
+const GRID_STEP = 8; // spacing between ground vertices
+function createGroundGeo(size) {
+  const seg = Math.max(1, Math.floor(size / GRID_STEP)); // keep detail consistent
+  const geo = new THREE.PlaneGeometry(size, size, seg, seg);
+  geo.rotateX(-Math.PI / 2);
+  return geo;
+}
+let groundGeo = createGroundGeo(groundSize);
 // Shader material snaps vertices to a grid so smooth ground appears voxel-like
 const groundMat = createVoxelTerrainMaterial();
 const ground = new THREE.Mesh(groundGeo, groundMat);
@@ -52,8 +57,7 @@ function setGroundSize(newSize) {
   if (groundSize === newSize) return;
   groundSize = newSize;
   ground.geometry.dispose();
-  groundGeo = new THREE.PlaneGeometry(groundSize, groundSize, GROUND_SEG, GROUND_SEG);
-  groundGeo.rotateX(-Math.PI / 2);
+  groundGeo = createGroundGeo(groundSize); // rebuild with density based on size
   ground.geometry = groundGeo;
   // Resize the water plane to match the new ground size.
   water.geometry.dispose();


### PR DESCRIPTION
## Summary
- Layer multiple noise sources to diversify terrain height generation
- Maintain terrain detail by rebuilding ground mesh with size-based density

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_6898d7ada8a0832a8201019603a951c1