### PR TITLE
Default to Terragen terrain and realign menus

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -36,11 +36,13 @@
     .panel .header { user-select: none; cursor: move; display: flex; align-items: center; gap: 8px; padding: 8px 10px; border-bottom: 1px solid rgba(255,255,255,.06); background: rgba(255,255,255,.04); border-top-left-radius: 12px; border-top-right-radius: 12px; }
     .panel .header .title { font-weight: 700; font-size: 12px; letter-spacing: .2px; opacity: .95; }
 
-    #settings { left: 12px; top: 12px; }
-    #builder { left: 12px; top: 200px; }
-    #worldgen { left: 12px; top: 388px; }
+/* Panel positions to prevent overlap */
+  #settings { left: 12px; top: 60px; }
+  #builder { left: 12px; top: 248px; }
+  #worldgen { left: 12px; top: 436px; }
+  #debug { left: 12px; top: 624px; }
 
-    #builderToggle { position: fixed; left: 12px; top: 12px; z-index: 6; padding: 6px 10px; font-size: 12px; border-radius: 10px; border: 1px solid rgba(255,255,255,.15); background: rgba(90,200,250,.25); color: #eaf7ff; cursor: pointer; }
-    #builderToggle:hover { filter: brightness(1.05); }
+  #builderToggle { position: fixed; left: 12px; top: 12px; z-index: 6; padding: 6px 10px; font-size: 12px; border-radius: 10px; border: 1px solid rgba(255,255,255,.15); background: rgba(90,200,250,.25); color: #eaf7ff; cursor: pointer; }
+  #builderToggle:hover { filter: brightness(1.05); }
   #procToggle { position: fixed; left: 132px; top: 12px; z-index: 6; padding: 6px 10px; font-size: 12px; border-radius: 10px; border: 1px solid rgba(255,255,255,.15); background: rgba(90,200,250,.25); color: #eaf7ff; cursor: pointer; }
   #procToggle:hover { filter: brightness(1.05); }

--- a/index.html
+++ b/index.html
@@ -91,7 +91,7 @@
       <div class="row"><label for="terrainType">Terrain type</label>
         <select id="terrainType">
           <option value="basic">Basic</option>
-          <option value="terragen">Terragen</option>
+          <option value="terragen" selected>Terragen</option>
         </select>
       </div>
       <button id="regen">Regenerate</button>

--- a/js/builder/index.js
+++ b/js/builder/index.js
@@ -32,7 +32,8 @@ export function toggleBuilder() {
   setBuilderVisible(builder.hidden);
 }
 builderToggle.addEventListener('click', () => toggleBuilder());
-setBuilderVisible(true);
+// Disable builder by default so the world starts without the editor
+setBuilderVisible(false);
 
 function addAABBForMesh(mesh) {
   mesh.updateMatrixWorld(true);

--- a/js/core/state.js
+++ b/js/core/state.js
@@ -5,7 +5,7 @@ const state = {
   worldSeed: 1,
   mountainAmp: 240,
   valleyAmp: 20,
-  terrainType: 'basic',
+  terrainType: 'terragen',
 };
 
 // Update the global seed used for terrain and chunk generation.


### PR DESCRIPTION
## Summary
- switch default terrain generation to Terragen and preselect it in the world gen menu
- space out settings, builder, worldgen, and debug panels to avoid overlapping
- start with the builder disabled so the editor is off by default

## Testing
- no tests were run


------
https://chatgpt.com/codex/tasks/task_e_6899085766b0832a8493d9be90050935