### PR TITLE
Align spawn, fix menus, add sea level option

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,6 +45,9 @@
       <div class="row"><label for="chunkSize">Chunk size</label>
         <input id="chunkSize" type="number" min="8" max="128" step="8" value="32" />
       </div>
+      <div class="row"><label for="seaLevel">Sea level</label>
+        <input id="seaLevel" type="number" step="1" value="-10" />
+      </div>
     </div>
   </div>
 

--- a/js/core/dom.js
+++ b/js/core/dom.js
@@ -27,6 +27,7 @@ const jumpInp = document.getElementById('jump');
 const stepHInp = document.getElementById('stepH');
 const viewDistInp = document.getElementById('viewDist');
 const chunkSizeInp = document.getElementById('chunkSize');
+const seaLevelInp = document.getElementById('seaLevel');
 
 const worldgenPanel = document.getElementById('worldgen');
 const worldHandle = document.getElementById('worldHandle');
@@ -71,6 +72,7 @@ export {
   stepHInp,
   viewDistInp,
   chunkSizeInp,
+  seaLevelInp,
   worldgenPanel,
   worldHandle,
   seedInp,

--- a/js/core/index.js
+++ b/js/core/index.js
@@ -14,7 +14,16 @@ export {
   sky,
   updateEnvironment,
 } from './environment.js';
-export { ground, water, SEA_LEVEL, heightAt, maybeRecenterGround, rebuildGround, setGroundSize } from '../world/terrain.js';
+export {
+  ground,
+  water,
+  SEA_LEVEL,
+  heightAt,
+  maybeRecenterGround,
+  rebuildGround,
+  setGroundSize,
+  setSeaLevel,
+} from '../world/terrain.js';
 export {
   grid,
   blocks,
@@ -55,6 +64,7 @@ export {
   stepHInp,
   viewDistInp,
   chunkSizeInp,
+  seaLevelInp,
   worldgenPanel,
   worldHandle,
   seedInp,
@@ -69,3 +79,4 @@ export {
   dbgGround,
 } from './dom.js';
 export { state, setWorldSeed, setTerrainAmps, setTerrainType } from './state.js';
+export { alignPlayerToGround } from '../world/controls.js';

--- a/js/player/controls.js
+++ b/js/player/controls.js
@@ -18,6 +18,7 @@ import {
   worldgenPanel,
   state,
   debugPanel,
+  alignPlayerToGround,
   } from '../core/index.js';
   import { updatePreview } from '../builder/preview.js';
 
@@ -130,6 +131,7 @@ controls.addEventListener('lock', () => {
   mouseEnabled = false;
   state.mouseEnabled = false;
   showUI(true);
+  alignPlayerToGround();
   updatePreview();
 });
 controls.addEventListener('unlock', () => {

--- a/js/player/movement/loop.js
+++ b/js/player/movement/loop.js
@@ -27,6 +27,7 @@ import {
   maybeRecenterGround,
   rebuildAABBs,
   updateEnvironment,
+  alignPlayerToGround,
 } from '../../core/index.js';
 import { constrainPanel } from '../../ui.js';
 import movement from './state.js';
@@ -118,6 +119,7 @@ function animate() {
     if (obj.position.y < -20) {
       obj.position.set(0, movement.playerHeight + 1, 0);
       movement.vForward = movement.vRight = movement.vY = 0;
+      alignPlayerToGround();
     }
     controls.moveForward(movement.vForward * delta);
     controls.moveRight(movement.vRight * delta);
@@ -170,3 +172,4 @@ window.addEventListener('resize', () => {
   constrainPanel(worldgenPanel);
 });
 controls.getObject().position.set(0, movement.playerHeight + 1, 8);
+alignPlayerToGround();

--- a/js/ui.js
+++ b/js/ui.js
@@ -76,3 +76,21 @@ makeDraggable(settingsPanel, settingsHandle, 'ui.settings.pos');
 makeDraggable(builder, builderHandle, 'ui.builder.pos');
 makeDraggable(worldgenPanel, worldHandle, 'ui.worldgen.pos');
 makeDraggable(debugPanel, debugHandle, 'ui.debug.pos');
+
+// Set default positions so panels don't overlap on first load
+if (!localStorage.getItem('ui.settings.pos')) {
+  settingsPanel.style.left = '12px';
+  settingsPanel.style.top = '60px';
+}
+if (!localStorage.getItem('ui.builder.pos')) {
+  builder.style.left = '12px';
+  builder.style.top = '248px';
+}
+if (!localStorage.getItem('ui.worldgen.pos')) {
+  worldgenPanel.style.left = '12px';
+  worldgenPanel.style.top = '436px';
+}
+if (!localStorage.getItem('ui.debug.pos')) {
+  debugPanel.style.left = '12px';
+  debugPanel.style.top = '624px';
+}

--- a/js/world/controls.js
+++ b/js/world/controls.js
@@ -13,9 +13,11 @@ import {
   setWorldSeed,
   setTerrainAmps,
   setTerrainType,
+  setSeaLevel,
   controls,
   heightAt,
   SEA_LEVEL,
+  seaLevelInp,
   } from '../core/index.js';
 
 // Generate a random 32-bit seed.
@@ -69,3 +71,16 @@ procToggle.addEventListener('click', () => {
   const on = toggleProcgen();
   procToggle.textContent = on ? 'Objects: On' : 'Objects: Off';
 });
+
+// Update sea level when the option changes
+seaLevelInp.addEventListener('change', () => {
+  let level = parseFloat(seaLevelInp.value);
+  if (!Number.isFinite(level)) {
+    level = -10;
+    seaLevelInp.value = level;
+  }
+  setSeaLevel(level);
+  alignPlayerToGround();
+});
+
+export { alignPlayerToGround };

--- a/js/world/terrain.js
+++ b/js/world/terrain.js
@@ -3,7 +3,7 @@ import { createTerrainMaterial } from '../core/shaders.js';
 import { heightAt } from './heightmap.js';
 
 // Water level for oceans, lakes, and rivers
-const SEA_LEVEL = -10;
+let SEA_LEVEL = -10;
 
 // Allow the ground plane to expand as view distance increases
 let groundSize = 800;
@@ -89,4 +89,19 @@ function maybeRecenterGround(playerX, playerZ) {
   return { shifted: false, dx: 0, dz: 0 };
 }
 
-export { ground, water, SEA_LEVEL, heightAt, maybeRecenterGround, rebuildGround, setGroundSize };
+// Update sea level and rebuild water position
+function setSeaLevel(newLevel) {
+  SEA_LEVEL = newLevel;
+  rebuildGround();
+}
+
+export {
+  ground,
+  water,
+  SEA_LEVEL,
+  heightAt,
+  maybeRecenterGround,
+  rebuildGround,
+  setGroundSize,
+  setSeaLevel,
+};


### PR DESCRIPTION
## Summary
- Align player to terrain on spawn and respawn
- Prevent UI panels from overlapping by setting default positions
- Expose adjustable sea level and update world accordingly

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_68990f67ce28832aaf66f9d1029a7305