### PR TITLE
Set Terragen sea level to 130 and refine LOD increments

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@
         <input id="chunkSize" type="number" min="8" max="128" step="8" value="32" />
       </div>
       <div class="row"><label for="seaLevel">Sea level</label>
-        <input id="seaLevel" type="number" step="1" value="-10" />
+        <input id="seaLevel" type="number" step="1" value="130" />
       </div>
     </div>
   </div>

--- a/js/world/controls.js
+++ b/js/world/controls.js
@@ -76,7 +76,7 @@ procToggle.addEventListener('click', () => {
 seaLevelInp.addEventListener('change', () => {
   let level = parseFloat(seaLevelInp.value);
   if (!Number.isFinite(level)) {
-    level = -10;
+    level = 130;
     seaLevelInp.value = level;
   }
   setSeaLevel(level);

--- a/js/world/procgen.js
+++ b/js/world/procgen.js
@@ -18,8 +18,8 @@ const loaded = new Map();
 let PROC_ENABLED = false;
 let CHUNK_SIZE = 32;
 let VIEW_DIST = 5;
-// Precomputed LOD thresholds in chunk units
-let LOD_RANGES = [5, 10, 15, 20];
+// Precomputed LOD thresholds in chunk units with smaller increments
+let LOD_RANGES = [5, 7.5, 10, 12.5];
 
 function key(cx, cz) {
   return cx + ',' + cz;
@@ -98,8 +98,8 @@ function updateChunks(force = false, forcedPos = null) {
   lastChunkUpdate = now;
   CHUNK_SIZE = Math.max(8, parseInt(chunkSizeInp.value) || 32);
   VIEW_DIST = Math.max(1, Math.min(64, parseInt(viewDistInp.value) || 10));
-  // Define four LOD bands expanding the view distance
-  LOD_RANGES = [VIEW_DIST, VIEW_DIST * 2, VIEW_DIST * 3, VIEW_DIST * 4];
+  // Define four LOD bands with smaller incremental steps
+  LOD_RANGES = [VIEW_DIST, VIEW_DIST * 1.5, VIEW_DIST * 2, VIEW_DIST * 2.5];
   // Resize ground to cover the most distant LOD ring
   setGroundSize((LOD_RANGES[3] * 2 + 2) * CHUNK_SIZE);
   // Update collision data for resized terrain

--- a/js/world/terrain.js
+++ b/js/world/terrain.js
@@ -2,8 +2,8 @@ import { THREE, scene } from '../core/environment.js';
 import { createTerrainMaterial } from '../core/shaders.js';
 import { heightAt } from './heightmap.js';
 
-// Water level for oceans, lakes, and rivers
-let SEA_LEVEL = -10;
+// Water level for oceans, lakes, and rivers (default 130 units)
+let SEA_LEVEL = 130;
 
 // Allow the ground plane to expand as view distance increases
 let groundSize = 800;


### PR DESCRIPTION
## Summary
- Raise default Terragen sea level to 130 and update UI and controls accordingly
- Reduce LOD step ranges for smoother transitions

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_689917f55d20832a82ddd7d90afe5d85