### PR TITLE
feat: add terrain color variations

### DIFF
--- a/js/core/shaders.js
+++ b/js/core/shaders.js
@@ -23,7 +23,8 @@ function createBlockMaterial(color) {
 
 // Create a standard material for smooth terrain
 function createTerrainMaterial() {
-  return new THREE.MeshStandardMaterial({ color: 0x35506e, roughness: 0.95 });
+  // Allow per-vertex colors so ground can show varied terrain shades
+  return new THREE.MeshStandardMaterial({ vertexColors: true, roughness: 0.95 });
 }
 
 export { createBlockMaterial, createTerrainMaterial };

--- a/js/world/heightmap.js
+++ b/js/world/heightmap.js
@@ -121,4 +121,5 @@ function heightAt(x, z) {
     : basicHeightAt(x, z);
 }
 
-export { heightAt };
+// Export height function and noise so other modules (e.g., terrain coloring) can use them
+export { heightAt, fbm2D };


### PR DESCRIPTION
## Summary
- enable per-vertex colors for terrain material
- expose fractal noise generator
- color ground based on height, slope, and noise

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_68991cad2a10832a8961487651d3f21d