### PR TITLE
Add terrain appearance customization menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,6 +97,25 @@
           <option value="terragen" selected>Terragen</option>
         </select>
       </div>
+      <h2 style="margin-top:10px">Terrain Appearance</h2>
+      <div class="row"><label for="waterFloorColor">Water floor</label>
+        <input id="waterFloorColor" type="color" value="#5c6e7e" />
+      </div>
+      <div class="row"><label for="grassA">Grass A</label>
+        <input id="grassA" type="color" value="#2e8f2e" />
+      </div>
+      <div class="row"><label for="grassB">Grass B</label>
+        <input id="grassB" type="color" value="#5cad49" />
+      </div>
+      <div class="row"><label for="stoneColor">Stone</label>
+        <input id="stoneColor" type="color" value="#777777" />
+      </div>
+      <div class="row"><label for="rockSlopeStart">Rock slope start</label>
+        <input id="rockSlopeStart" type="number" step="0.1" value="2" />
+      </div>
+      <div class="row"><label for="rockSlopeRange">Rock slope range</label>
+        <input id="rockSlopeRange" type="number" step="0.1" value="10" />
+      </div>
       <button id="regen">Regenerate</button>
     </div>
   </div>

--- a/js/core/dom.js
+++ b/js/core/dom.js
@@ -36,6 +36,12 @@ const regenBtn = document.getElementById('regen');
 const mountainAmpInp = document.getElementById('mountainAmp');
 const valleyAmpInp = document.getElementById('valleyAmp');
 const terrainTypeSel = document.getElementById('terrainType');
+const waterFloorColorInp = document.getElementById('waterFloorColor');
+const grassAInp = document.getElementById('grassA');
+const grassBInp = document.getElementById('grassB');
+const stoneColorInp = document.getElementById('stoneColor');
+const rockSlopeStartInp = document.getElementById('rockSlopeStart');
+const rockSlopeRangeInp = document.getElementById('rockSlopeRange');
 
 const debugPanel = document.getElementById('debug');
 const debugHandle = document.getElementById('debugHandle');
@@ -80,6 +86,12 @@ export {
   mountainAmpInp,
   valleyAmpInp,
   terrainTypeSel,
+  waterFloorColorInp,
+  grassAInp,
+  grassBInp,
+  stoneColorInp,
+  rockSlopeStartInp,
+  rockSlopeRangeInp,
   debugPanel,
   debugHandle,
   dbgTests,

--- a/js/core/index.js
+++ b/js/core/index.js
@@ -23,6 +23,8 @@ export {
   rebuildGround,
   setGroundSize,
   setSeaLevel,
+  setTerrainOptions,
+  getTerrainOptions,
 } from '../world/terrain.js';
 export {
   grid,
@@ -72,6 +74,12 @@ export {
   mountainAmpInp,
   valleyAmpInp,
   terrainTypeSel,
+  waterFloorColorInp,
+  grassAInp,
+  grassBInp,
+  stoneColorInp,
+  rockSlopeStartInp,
+  rockSlopeRangeInp,
   debugPanel,
   debugHandle,
   dbgTests,

--- a/js/world/controls.js
+++ b/js/world/controls.js
@@ -14,11 +14,18 @@ import {
   setTerrainAmps,
   setTerrainType,
   setSeaLevel,
+  setTerrainOptions,
   controls,
   heightAt,
   SEA_LEVEL,
   seaLevelInp,
-  } from '../core/index.js';
+  waterFloorColorInp,
+  grassAInp,
+  grassBInp,
+  stoneColorInp,
+  rockSlopeStartInp,
+  rockSlopeRangeInp,
+} from '../core/index.js';
 
 // Generate a random 32-bit seed.
 function randomSeed() {
@@ -34,6 +41,12 @@ function alignPlayerToGround() {
   if (obj.position.y < groundY) {
     obj.position.y = groundY;
   }
+}
+
+// Apply terrain option changes and rebuild the ground mesh.
+function updateTerrain(opts) {
+  setTerrainOptions(opts);
+  rebuildGround();
 }
 
 // Apply seed and rebuild world when the regenerate button is pressed.
@@ -81,6 +94,46 @@ seaLevelInp.addEventListener('change', () => {
   }
   setSeaLevel(level);
   alignPlayerToGround();
+});
+
+// Update water floor color when the option changes
+waterFloorColorInp.addEventListener('change', () => {
+  updateTerrain({ waterFloorColor: waterFloorColorInp.value });
+});
+
+// Update grass shade A when the option changes
+grassAInp.addEventListener('change', () => {
+  updateTerrain({ grassA: grassAInp.value });
+});
+
+// Update grass shade B when the option changes
+grassBInp.addEventListener('change', () => {
+  updateTerrain({ grassB: grassBInp.value });
+});
+
+// Update stone color when the option changes
+stoneColorInp.addEventListener('change', () => {
+  updateTerrain({ stoneColor: stoneColorInp.value });
+});
+
+// Update slope value where rocks begin to appear
+rockSlopeStartInp.addEventListener('change', () => {
+  let v = parseFloat(rockSlopeStartInp.value);
+  if (!Number.isFinite(v)) {
+    v = 2;
+    rockSlopeStartInp.value = v;
+  }
+  updateTerrain({ rockSlopeStart: v });
+});
+
+// Update additional slope needed to become full rock
+rockSlopeRangeInp.addEventListener('change', () => {
+  let v = parseFloat(rockSlopeRangeInp.value);
+  if (!Number.isFinite(v)) {
+    v = 10;
+    rockSlopeRangeInp.value = v;
+  }
+  updateTerrain({ rockSlopeRange: v });
 });
 
 export { alignPlayerToGround };


### PR DESCRIPTION
## Summary
- expose terrain color and slope settings via new inputs in the world generation panel
- wire up DOM references and exports for color and slope controls
- rebuild terrain when colors or slope thresholds change

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_6899217ddabc832aa929e8a155c6d530