### PR TITLE
Fix height shader compilation by declaring noise uniforms

### DIFF
--- a/js/world/chunkedTerrain.js
+++ b/js/world/chunkedTerrain.js
@@ -28,6 +28,8 @@ const heightMaterial = new THREE.ShaderMaterial({
     }
   `,
   fragmentShader: `
+    uniform vec2 uOffset;   // Offset for noise lookup
+    uniform float uScale;   // Scale of noise sampling
     // 2D OpenSimplex noise adapted for GLSL
     vec3 mod289(vec3 x){return x - floor(x * (1.0 / 289.0)) * 289.0;}
     vec2 mod289(vec2 x){return x - floor(x * (1.0 / 289.0)) * 289.0;}


### PR DESCRIPTION
## Summary
- declare `uOffset` and `uScale` as uniforms in height map fragment shader to fix compilation

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_68993431762c832a9ac69b97bc4fd289