### PR TITLE
Add shader-based water with animated waves

### DIFF
--- a/js/player/movement/loop.js
+++ b/js/player/movement/loop.js
@@ -11,6 +11,7 @@ import {
   sunDir,
   sky,
   ground,
+  water,
   blocks,
   fpsBox,
   posBox,
@@ -191,6 +192,10 @@ function animate() {
   updateChunks();
   updateTerrainChunks();
   updateHeightTexture(new THREE.Vector2(camera.position.x, camera.position.z));
+  // Drive water wave animation by advancing the time uniform
+  if (water.material.userData.shader) {
+    water.material.userData.shader.uniforms.uTime.value += delta;
+  }
   if (state.isActive && (!window.__DEBUG || window.__DEBUG.movement)) {
     const obj = updatePlayerMovement(delta);
     updateLighting(obj);

--- a/js/world/terrain.js
+++ b/js/world/terrain.js
@@ -27,7 +27,21 @@ ground.castShadow = ground.receiveShadow = true;
 // Flat water plane that fills low-lying terrain
 let waterGeo = new THREE.PlaneGeometry(groundSize, groundSize, 1, 1);
 waterGeo.rotateX(-Math.PI / 2);
+// Start from a standard material so lighting and reflections stay intact
 const waterMat = new THREE.MeshStandardMaterial({ color: 0x1e90ff, transparent: true, opacity: 0.6 });
+// Inject a simple wave shader that displaces vertices over time
+waterMat.onBeforeCompile = (shader) => {
+  shader.uniforms.uTime = { value: 0 };
+  shader.vertexShader = shader.vertexShader.replace(
+    '#include <common>',
+    '#include <common>\nuniform float uTime;'
+  );
+  shader.vertexShader = shader.vertexShader.replace(
+    '#include <begin_vertex>',
+    '#include <begin_vertex>\n  transformed.y += (sin((position.x + uTime) * 0.1) + sin((position.z + uTime) * 0.1)) * 0.5;'
+  );
+  waterMat.userData.shader = shader;
+};
 const water = new THREE.Mesh(waterGeo, waterMat);
 // Let water reflect light but not cast shadows
 water.receiveShadow = true;


### PR DESCRIPTION
## Summary
- Add custom wave shader to water mesh for ripple animation
- Update animation loop to drive water wave uniform

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_689a68ba2a0c832a8bc44e825b796c63