### PR TITLE
Add weather effects with rain and snow

### DIFF
--- a/js/core/environment.js
+++ b/js/core/environment.js
@@ -1,6 +1,7 @@
 import * as THREE from 'three';
 import { PointerLockControls } from 'three/addons/controls/PointerLockControls.js';
 import { Sky } from 'three/addons/objects/Sky.js';
+import { initWeather, getWeather } from './weather.js';
 
 // Scene and camera
 const scene = new THREE.Scene();
@@ -62,6 +63,20 @@ function updateEnvironment(elevation) {
   sunLight.color.copy(sunCol);
   sunLight.intensity = 0.2 + 0.8 * t;
   hemi.intensity = 0.1 + 0.9 * t;
+  const weather = getWeather();
+  if (weather === 'rain') {
+    sunLight.intensity *= 0.6;
+    hemi.intensity *= 0.7;
+    const rainFog = bg.clone().lerp(new THREE.Color(0x555555), 0.3);
+    scene.background.copy(rainFog);
+    scene.fog.color.copy(rainFog);
+  } else if (weather === 'snow') {
+    sunLight.intensity *= 0.8;
+    hemi.intensity *= 0.8;
+    const snowFog = bg.clone().lerp(new THREE.Color(0xffffff), 0.5);
+    scene.background.copy(snowFog);
+    scene.fog.color.copy(snowFog);
+  }
 }
 
 // Lights
@@ -103,6 +118,7 @@ scene.add(moon);
 // Controls
 const controls = new PointerLockControls(camera, document.body);
 scene.add(controls.getObject());
+initWeather(scene);
 
 export {
   THREE,

--- a/js/core/index.js
+++ b/js/core/index.js
@@ -89,3 +89,4 @@ export {
 } from './dom.js';
 export { state, setWorldSeed, setTerrainAmps, setTerrainType } from './state.js';
 export { alignPlayerToGround } from '../world/controls.js';
+export { initWeather, setWeather, getWeather, updateWeather } from './weather.js';

--- a/js/core/weather.js
+++ b/js/core/weather.js
@@ -1,0 +1,103 @@
+import * as THREE from 'three';
+
+// Active weather state: 'clear', 'rain', or 'snow'
+let current = 'clear';
+
+// Particle systems for different weather types
+let rain, snow;
+
+/**
+ * Create a simple particle system for rain using THREE.Points.
+ * @returns {{points: THREE.Points, positions: Float32Array, geom: THREE.BufferGeometry}}
+ */
+function createRain() {
+  const geom = new THREE.BufferGeometry();
+  const count = 1000;
+  const positions = new Float32Array(count * 3);
+  for (let i = 0; i < count; i++) {
+    positions[i * 3] = (Math.random() - 0.5) * 200;
+    positions[i * 3 + 1] = Math.random() * 100 + 50;
+    positions[i * 3 + 2] = (Math.random() - 0.5) * 200;
+  }
+  geom.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+  const mat = new THREE.PointsMaterial({ color: 0xaaaaaa, size: 0.1 });
+  const points = new THREE.Points(geom, mat);
+  points.visible = false;
+  return { points, positions, geom };
+}
+
+/**
+ * Create a particle system for snow using THREE.Points.
+ * @returns {{points: THREE.Points, positions: Float32Array, geom: THREE.BufferGeometry}}
+ */
+function createSnow() {
+  const geom = new THREE.BufferGeometry();
+  const count = 1000;
+  const positions = new Float32Array(count * 3);
+  for (let i = 0; i < count; i++) {
+    positions[i * 3] = (Math.random() - 0.5) * 200;
+    positions[i * 3 + 1] = Math.random() * 100 + 50;
+    positions[i * 3 + 2] = (Math.random() - 0.5) * 200;
+  }
+  geom.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+  const mat = new THREE.PointsMaterial({ color: 0xffffff, size: 0.2 });
+  const points = new THREE.Points(geom, mat);
+  points.visible = false;
+  return { points, positions, geom };
+}
+
+/**
+ * Initialize weather particle systems and add them to the scene.
+ * @param {THREE.Scene} scene Scene to attach particle systems to.
+ */
+function initWeather(scene) {
+  rain = createRain();
+  snow = createSnow();
+  scene.add(rain.points);
+  scene.add(snow.points);
+}
+
+/**
+ * Set the active weather state.
+ * @param {'clear'|'rain'|'snow'} state Desired weather state.
+ */
+function setWeather(state) {
+  current = state;
+  rain.points.visible = state === 'rain';
+  snow.points.visible = state === 'snow';
+}
+
+/**
+ * Retrieve current weather state.
+ * @returns {'clear'|'rain'|'snow'}
+ */
+function getWeather() {
+  return current;
+}
+
+/**
+ * Update the active weather particle system.
+ * @param {number} delta Time since last frame in seconds.
+ */
+function updateWeather(delta) {
+  if (current === 'rain') {
+    const pos = rain.positions;
+    for (let i = 0; i < pos.length; i += 3) {
+      pos[i + 1] -= 100 * delta;
+      if (pos[i + 1] < 0) pos[i + 1] = Math.random() * 100 + 50;
+    }
+    rain.geom.attributes.position.needsUpdate = true;
+  } else if (current === 'snow') {
+    const pos = snow.positions;
+    for (let i = 0; i < pos.length; i += 3) {
+      pos[i] += (Math.random() - 0.5) * delta * 1;
+      pos[i + 2] += (Math.random() - 0.5) * delta * 1;
+      pos[i + 1] -= 10 * delta;
+      if (pos[i + 1] < 0) pos[i + 1] = Math.random() * 100 + 50;
+    }
+    snow.geom.attributes.position.needsUpdate = true;
+  }
+}
+
+export { initWeather, setWeather, getWeather, updateWeather };
+

--- a/js/player/movement/loop.js
+++ b/js/player/movement/loop.js
@@ -30,6 +30,7 @@ import {
   maybeRecenterGround,
   rebuildAABBs,
   updateEnvironment,
+  updateWeather,
   alignPlayerToGround,
 } from '../../core/index.js';
 import { constrainPanel } from '../../ui.js';
@@ -188,6 +189,7 @@ function animate() {
     acc = 0;
   }
   updateDayNightCycle(delta);
+  updateWeather(delta);
   updateChunks();
   updateTerrainChunks();
   updateHeightTexture(new THREE.Vector2(camera.position.x, camera.position.z));

--- a/js/ui.js
+++ b/js/ui.js
@@ -7,6 +7,8 @@ import {
   worldHandle,
   debugPanel,
   debugHandle,
+  setWeather,
+  getWeather,
 } from './core/index.js';
 
 function constrainPanel(panel) {
@@ -76,6 +78,26 @@ makeDraggable(settingsPanel, settingsHandle, 'ui.settings.pos');
 makeDraggable(builder, builderHandle, 'ui.builder.pos');
 makeDraggable(worldgenPanel, worldHandle, 'ui.worldgen.pos');
 makeDraggable(debugPanel, debugHandle, 'ui.debug.pos');
+
+// Dropdown in settings panel to switch weather states
+const weatherRow = document.createElement('div');
+weatherRow.className = 'row';
+const weatherLabel = document.createElement('label');
+weatherLabel.textContent = 'Weather';
+weatherLabel.setAttribute('for', 'weather');
+const weatherSel = document.createElement('select');
+weatherSel.id = 'weather';
+['clear', 'rain', 'snow'].forEach((w) => {
+  const o = document.createElement('option');
+  o.value = w;
+  o.textContent = w.charAt(0).toUpperCase() + w.slice(1);
+  weatherSel.appendChild(o);
+});
+weatherRow.appendChild(weatherLabel);
+weatherRow.appendChild(weatherSel);
+settingsPanel.querySelector('.panel-body').appendChild(weatherRow);
+weatherSel.value = getWeather();
+weatherSel.addEventListener('change', () => setWeather(weatherSel.value));
 
 // Set default positions so panels don't overlap on first load
 if (!localStorage.getItem('ui.settings.pos')) {


### PR DESCRIPTION
## Summary
- introduce a dedicated weather system handling clear, rain, and snow particles
- dim lighting and shift fog colors based on current weather
- add settings dropdown to switch weather and update loop tick

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_689a68b92850832a987fc0593e7b87af