### PR TITLE
feat: add basic wildlife

### DIFF
--- a/js/core/index.js
+++ b/js/core/index.js
@@ -38,6 +38,7 @@ export {
 } from '../world/world.js';
 export { updateChunks, worldToChunk, resetChunks, toggleProcgen } from '../world/procgen.js';
 export { updateTerrainChunks, updateHeightTexture, populateVegetation, finalizeStatic } from '../world/chunkedTerrain.js';
+export { spawnCreatures, updateCreatures } from '../world/creatures/index.js';
 export {
   overlay,
   startBtn,

--- a/js/player/movement/loop.js
+++ b/js/player/movement/loop.js
@@ -27,6 +27,7 @@ import {
   updateTerrainChunks,
   updateHeightTexture,
   populateVegetation,
+  updateCreatures,
   maybeRecenterGround,
   rebuildAABBs,
   updateEnvironment,
@@ -191,6 +192,7 @@ function animate() {
   updateChunks();
   updateTerrainChunks();
   updateHeightTexture(new THREE.Vector2(camera.position.x, camera.position.z));
+  updateCreatures(delta);
   if (state.isActive && (!window.__DEBUG || window.__DEBUG.movement)) {
     const obj = updatePlayerMovement(delta);
     updateLighting(obj);

--- a/js/world/chunkedTerrain.js
+++ b/js/world/chunkedTerrain.js
@@ -1,6 +1,7 @@
 import { THREE, scene, camera, renderer } from '../core/environment.js';
 // Import the utility functions for merging geometries
 import { mergeBufferGeometries } from 'three/addons/utils/BufferGeometryUtils.js';
+import { spawnCreatures } from './creatures/index.js';
 
 // Tile size in world units
 const TILE_SIZE = 64;
@@ -248,6 +249,8 @@ function populateVegetation(){
   }
   vegetation.instanceMatrix.needsUpdate = true;
   vegetation.frustumCulled = false;
+  // Populate basic creatures alongside vegetation
+  spawnCreatures();
 }
 
 // Merge static meshes and freeze materials for performance

--- a/js/world/creatures/index.js
+++ b/js/world/creatures/index.js
@@ -1,0 +1,55 @@
+import { THREE, scene } from '../../core/environment.js';
+import { heightAt } from '../heightmap.js';
+
+// Store all active creatures for updates
+const creatures = [];
+
+/**
+ * Spawn simple animal meshes at random terrain positions.
+ * Repeated calls are ignored once creatures exist.
+ * @param {number} count Number of creatures to spawn.
+ */
+function spawnCreatures(count = 10) {
+  if (creatures.length) return; // Prevent duplicate populations
+  for (let i = 0; i < count; i++) {
+    const isBird = Math.random() > 0.5;
+    let mesh;
+    if (isBird) {
+      // Basic sphere to represent a bird
+      const geo = new THREE.SphereGeometry(0.5, 8, 8);
+      const mat = new THREE.MeshStandardMaterial({ color: 0xffffff });
+      mesh = new THREE.Mesh(geo, mat);
+    } else {
+      // Simple box for a deer-like creature
+      const geo = new THREE.BoxGeometry(1, 1, 2);
+      const mat = new THREE.MeshStandardMaterial({ color: 0x8b5a2b });
+      mesh = new THREE.Mesh(geo, mat);
+    }
+    const x = (Math.random() - 0.5) * 1000;
+    const z = (Math.random() - 0.5) * 1000;
+    const y = heightAt(x, z);
+    mesh.position.set(x, y, z);
+    // Offset used for unique motion patterns
+    mesh.userData = { isBird, offset: Math.random() * Math.PI * 2 };
+    creatures.push(mesh);
+    scene.add(mesh);
+  }
+}
+
+/**
+ * Apply simple idle motion to all creatures.
+ * Birds bob vertically while deer rotate gently.
+ * @param {number} delta Time since last frame in seconds.
+ */
+function updateCreatures(delta) {
+  const t = performance.now() * 0.001;
+  creatures.forEach((c) => {
+    if (c.userData.isBird) {
+      c.position.y += Math.sin(t + c.userData.offset) * 0.5 * delta;
+    } else {
+      c.rotation.y += 0.2 * delta;
+    }
+  });
+}
+
+export { spawnCreatures, updateCreatures };


### PR DESCRIPTION
## Summary
- add creatures module with spawn and update routines
- expose wildlife hooks and update loop integration
- spawn animals alongside vegetation

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_689a68bc1238832a87bafd3d7b301607