### PR TITLE
Add diverse vegetation meshes

### DIFF
--- a/js/world/chunkedTerrain.js
+++ b/js/world/chunkedTerrain.js
@@ -176,14 +176,16 @@ const fullscreenScene = new THREE.Scene();
 const fullscreenCamera = new THREE.OrthographicCamera(-1,1,1,-1,0,1);
 fullscreenScene.add(new THREE.Mesh(new THREE.PlaneGeometry(2,2), heightMaterial));
 
-// Load tree and shrub models for instanced vegetation
+// Load vegetation models for instanced vegetation
 const loader = new GLTFLoader();
 const VEGETATION_COUNT = 2000;
 const vegetationMeshes = [];
 const vegetationModelPaths = [
   'models/tree.gltf',
-  'models/shrub.gltf'
-];
+  'models/shrub.gltf',
+  'models/bush.gltf',
+  'models/grass.gltf'
+]; // Include additional vegetation meshes
 vegetationModelPaths.forEach(url => {
   loader.load(url, gltf => {
     const source = gltf.scene.children[0];

--- a/models/bush.gltf
+++ b/models/bush.gltf
@@ -1,0 +1,15 @@
+{
+  "asset": {"version": "2.0"},
+  "scenes": [{"nodes": [0]}],
+  "nodes": [{"mesh": 0}],
+  "meshes": [{"primitives": [{"attributes": {"POSITION": 0}, "indices": 1}]}],
+  "buffers": [{"uri": "data:application/octet-stream;base64,AAAAAAAAAAAAAAAAAACAPwAAAAAAAAAAAAAAAAAAAAAAAIA/AAAAAAAAgD8AAAAAAAABAAIAAAABAAMAAQACAAMAAgAAAAMA", "byteLength": 72}],
+  "bufferViews": [
+    {"buffer": 0, "byteOffset": 0, "byteLength": 48, "target": 34962},
+    {"buffer": 0, "byteOffset": 48, "byteLength": 24, "target": 34963}
+  ],
+  "accessors": [
+    {"bufferView": 0, "componentType": 5126, "count": 4, "type": "VEC3", "max": [1, 1, 1], "min": [0, 0, 0]},
+    {"bufferView": 1, "componentType": 5123, "count": 12, "type": "SCALAR"}
+  ]
+}

--- a/models/grass.gltf
+++ b/models/grass.gltf
@@ -1,0 +1,15 @@
+{
+  "asset": {"version": "2.0"},
+  "scenes": [{"nodes": [0]}],
+  "nodes": [{"mesh": 0}],
+  "meshes": [{"primitives": [{"attributes": {"POSITION": 0}, "indices": 1}]}],
+  "buffers": [{"uri": "data:application/octet-stream;base64,AACAvgAAAAAAAAAAAACAPgAAAAAAAAAAAACAPgAAAD8AAAAAAACAvgAAAD8AAAAAAAABAAIAAAACAAMA", "byteLength": 60}],
+  "bufferViews": [
+    {"buffer": 0, "byteOffset": 0, "byteLength": 48, "target": 34962},
+    {"buffer": 0, "byteOffset": 48, "byteLength": 12, "target": 34963}
+  ],
+  "accessors": [
+    {"bufferView": 0, "componentType": 5126, "count": 4, "type": "VEC3", "max": [0.25, 0.5, 0], "min": [-0.25, 0, 0]},
+    {"bufferView": 1, "componentType": 5123, "count": 6, "type": "SCALAR"}
+  ]
+}


### PR DESCRIPTION
## Summary
- add bush and grass glTF models for more varied foliage
- include new vegetation meshes in terrain generation

No tests were run.

------
https://chatgpt.com/codex/tasks/task_e_689b391596a8832aa8aeffbccaffabec